### PR TITLE
Add auto-complete to birthday fields

### DIFF
--- a/lib/q-transformer.js
+++ b/lib/q-transformer.js
@@ -1,7 +1,13 @@
 // TODO: this shouldn't be here - default should be supplied at creation time
 const defaultTransformer = require('./transformers/default');
+const govukSelectTransformer = require('./transformers/govukSelect');
 
-function createQTransformer(transformers = {default: defaultTransformer}) {
+function createQTransformer(
+    transformers = {
+        default: defaultTransformer,
+        govukSelect: govukSelectTransformer
+    }
+) {
     function transform({
         schemaKey,
         schema,

--- a/lib/transformers/default.js
+++ b/lib/transformers/default.js
@@ -26,16 +26,15 @@ module.exports = ({
             return govukTextarea(args);
         }
 
-        if ('oneOf' in schema && schema.oneOf.length < 20) {
-            return govukRadios(args);
+        if ('oneOf' in schema) {
+            if (schema.oneOf.length < 20) {
+                return govukRadios(args);
+            }
+            return govukSelect(args);
         }
 
         if ('format' in schema && schema.format === 'date-time') {
             return govukDateInput(args);
-        }
-
-        if ('oneOf' in schema && schema.oneOf.length >= 20) {
-            return govukSelect(args);
         }
 
         return govukInput(args);

--- a/lib/transformers/default.js
+++ b/lib/transformers/default.js
@@ -6,6 +6,7 @@ const govukDateInput = require('./govukDateInput');
 const rawContent = require('./rawContent');
 const boolean = require('./boolean');
 const form = require('./form');
+const govukSelect = require('./govukSelect');
 
 // TODO: Tidy these args up e.g. duplicated in function body
 module.exports = ({
@@ -25,12 +26,16 @@ module.exports = ({
             return govukTextarea(args);
         }
 
-        if ('oneOf' in schema) {
+        if ('oneOf' in schema && schema.oneOf.length < 20) {
             return govukRadios(args);
         }
 
         if ('format' in schema && schema.format === 'date-time') {
             return govukDateInput(args);
+        }
+
+        if ('oneOf' in schema && schema.oneOf.length >= 20) {
+            return govukSelect(args);
         }
 
         return govukInput(args);

--- a/lib/transformers/form.js
+++ b/lib/transformers/form.js
@@ -128,7 +128,7 @@ function form({schemaKey, schema, options, transform, data, schemaErrors} = {}) 
 
     const nunjucksImports = getNunjucksImports(opts.transformOrder, transformations);
     const summaryText = generateErrorSummary(opts.transformOrder, transformations);
-    const buttonTitle = schema.context === 'summary' ? 'Agree and Submit' : 'Continue';
+    const buttonTitle = opts.isSummary ? 'Agree and Submit' : 'Continue';
 
     return `${summaryText}
         <form method="post">

--- a/lib/transformers/form.js
+++ b/lib/transformers/form.js
@@ -128,6 +128,7 @@ function form({schemaKey, schema, options, transform, data, schemaErrors} = {}) 
 
     const nunjucksImports = getNunjucksImports(opts.transformOrder, transformations);
     const summaryText = generateErrorSummary(opts.transformOrder, transformations);
+    const buttonTitle = schema.context === 'summary' ? 'Agree and Submit' : 'Continue';
 
     return `${summaryText}
         <form method="post">
@@ -145,7 +146,7 @@ function form({schemaKey, schema, options, transform, data, schemaErrors} = {}) 
                 })
                 .join('\n')}
             {{ govukButton({
-                text: "Continue"
+                text: "${buttonTitle}"
             }) }}
         </form>`;
 }

--- a/lib/transformers/govukDateInput.js
+++ b/lib/transformers/govukDateInput.js
@@ -97,9 +97,10 @@ module.exports = ({schemaKey, schema, options, data, schemaErrors} = {}) => {
         transformation.errorSummaryHREF = opts.errorSummaryHREF;
     }
 
-    if (schema.autoComplete) {
+    if (opts.autoComplete) {
         // add autocomplete to date fields. Only used for birthdays
         opts.macroOptions.items.forEach(item => {
+            // eslint-disable-next-line no-param-reassign
             item.autocomplete = `bday-${item.label.toLowerCase()}`;
         });
     }

--- a/lib/transformers/govukDateInput.js
+++ b/lib/transformers/govukDateInput.js
@@ -97,5 +97,12 @@ module.exports = ({schemaKey, schema, options, data, schemaErrors} = {}) => {
         transformation.errorSummaryHREF = opts.errorSummaryHREF;
     }
 
+    if (schema.autoComplete) {
+        // add autocomplete to date fields. Only used for birthdays
+        opts.macroOptions.items.forEach(item => {
+            item.autocomplete = `bday-${item.label.toLowerCase()}`;
+        });
+    }
+
     return transformation;
 };

--- a/lib/transformers/govukInput.js
+++ b/lib/transformers/govukInput.js
@@ -27,6 +27,23 @@ module.exports = ({schemaKey, schema, options, data, schemaErrors} = {}) => {
         };
     }
 
+    // Add classes to give an appropriate length of field
+
+    if (schema.maxLength) {
+        // default values will not have a maxLength attribute - only add this if you need to change it!
+        if (schema.maxLength < 20) {
+            // 25% field
+            opts.macroOptions.classes = 'govuk-input--width-10';
+        } else if (schema.maxLength >= 20 && schema.maxLength < 60) {
+            // 50% field
+            opts.macroOptions.classes = 'govuk-input--width-20';
+        }
+        // Greater than 60 will but less that 500 will return 75% field. Greater than 500 will render as a text area.
+        else {
+            opts.macroOptions.classes = 'govuk-input--width-30';
+        }
+    }
+
     // Override defaults
     opts = merge(opts, options);
 

--- a/lib/transformers/govukRadios.js
+++ b/lib/transformers/govukRadios.js
@@ -90,7 +90,7 @@ module.exports = ({schemaKey, schema, options, transformations, data, schemaErro
 
                 // As this component will be nested, change its presentation
                 // TODO: how to handle existing classes?
-                component.macroOptions.classes = 'govuk-!-width-one-third';
+                // component.macroOptions.classes = 'govuk-!-width-one-third';
 
                 return component;
             });

--- a/lib/transformers/govukRadios.js
+++ b/lib/transformers/govukRadios.js
@@ -88,10 +88,6 @@ module.exports = ({schemaKey, schema, options, transformations, data, schemaErro
                     throw Error(`No transformation found for component id: "${componentId}"`);
                 }
 
-                // As this component will be nested, change its presentation
-                // TODO: how to handle existing classes?
-                // component.macroOptions.classes = 'govuk-!-width-one-third';
-
                 return component;
             });
 

--- a/lib/transformers/govukSelect.js
+++ b/lib/transformers/govukSelect.js
@@ -1,0 +1,59 @@
+const merge = require('lodash.merge');
+
+module.exports = ({schemaKey, schema, options, data, schemaErrors} = {}) => {
+    let opts = {
+        id: schemaKey,
+        dependencies: ['{% from "select/macro.njk" import govukSelect %}'],
+        componentName: 'govukSelect',
+        macroOptions: {
+            name: schemaKey,
+            label: {
+                text: schema.title
+            },
+            hint: schema.description ? {text: schema.description} : null
+        }
+    };
+
+    opts.macroOptions.items = schema.oneOf.map(subSchema => {
+        const item = {
+            value: subSchema.const,
+            text: subSchema.title
+        };
+
+        // Pre-populate with supplied data
+        if (schemaKey in data) {
+            // Values will be an array of checkbox values e.g. [ 'mines', 'farm', ...]
+            const values = data[schemaKey];
+
+            // If this item's value is included in the values, set it to checked
+            if (values.includes(item.value)) {
+                item.selected = true;
+            }
+        }
+
+        return item;
+    });
+
+    // Include errors
+    if (opts.macroOptions.name in schemaErrors) {
+        opts.macroOptions.errorMessage = {
+            text: schemaErrors[opts.macroOptions.name]
+        };
+    }
+
+    // Override defaults
+    opts = merge(opts, options);
+
+    // Configure page heading
+    if (opts.setPageHeading) {
+        opts.macroOptions.label.isPageHeading = true;
+        opts.macroOptions.label.classes = 'govuk-label--xl';
+    }
+
+    return {
+        id: opts.id,
+        dependencies: opts.dependencies,
+        componentName: opts.componentName,
+        macroOptions: opts.macroOptions
+    };
+};

--- a/lib/transformers/govukSelect.js
+++ b/lib/transformers/govukSelect.js
@@ -22,10 +22,9 @@ module.exports = ({schemaKey, schema, options, data, schemaErrors} = {}) => {
 
         // Pre-populate with supplied data
         if (schemaKey in data) {
-            // Values will be an array of checkbox values e.g. [ 'mines', 'farm', ...]
             const values = data[schemaKey];
 
-            // If this item's value is included in the values, set it to checked
+            // If this item's value is included in the values, set it to selected
             if (values.includes(item.value)) {
                 item.selected = true;
             }

--- a/test/q-transformer.test.js
+++ b/test/q-transformer.test.js
@@ -916,8 +916,7 @@ describe('qTransformer', () => {
                                                     },
                                                     "hint": {
                                                         "text": "e.g. something@something.com"
-                                                    },
-                                                    "classes": "govuk-!-width-one-third"
+                                                    }
                                                 })
                                             ] | join())
                                         }
@@ -934,8 +933,7 @@ describe('qTransformer', () => {
                                                     "label": {
                                                         "text": "Phone number"
                                                     },
-                                                    "hint": null,
-                                                    "classes": "govuk-!-width-one-third"
+                                                    "hint": null
                                                 })
                                             ] | join())
                                         }
@@ -952,8 +950,7 @@ describe('qTransformer', () => {
                                                     "label": {
                                                         "text": "Mobile phone number"
                                                     },
-                                                    "hint": null,
-                                                    "classes": "govuk-!-width-one-third"
+                                                    "hint": null
                                                 })
                                             ] | join())
                                         }
@@ -1103,8 +1100,7 @@ describe('qTransformer', () => {
                                                     },
                                                     "hint": {
                                                         "text": "e.g. something@something.com"
-                                                    },
-                                                    "classes": "govuk-!-width-one-third"
+                                                    }
                                                 }),
                                                 govukInput({
                                                     "id": "phone",
@@ -1113,8 +1109,7 @@ describe('qTransformer', () => {
                                                     "label": {
                                                         "text": "Phone number"
                                                     },
-                                                    "hint": null,
-                                                    "classes": "govuk-!-width-one-third"
+                                                    "hint": null
                                                 }),
                                                 govukInput({
                                                     "id": "text",
@@ -1123,8 +1118,7 @@ describe('qTransformer', () => {
                                                     "label": {
                                                         "text": "Mobile phone number"
                                                     },
-                                                    "hint": null,
-                                                    "classes": "govuk-!-width-one-third"
+                                                    "hint": null
                                                 })
                                             ] | join())
                                         }

--- a/test/q-transformer.test.js
+++ b/test/q-transformer.test.js
@@ -2115,4 +2115,105 @@ describe('qTransformer', () => {
             expect(removeIndentation(result)).toEqual(removeIndentation(expected));
         });
     });
+
+    describe('Display text inputs with appropriate classes', () => {
+        it('should add "width-10" class if text input has maxLength less than 20', () => {
+            const result = qTransformer.transform({
+                schemaKey: 'event-name',
+                schema: {
+                    type: 'string',
+                    title: 'Event name',
+                    description: "The name you'll use on promotional material.",
+                    maxLength: 19
+                },
+                uiSchema: {}
+            });
+
+            const expected = {
+                id: 'event-name',
+                dependencies: ['{% from "input/macro.njk" import govukInput %}'],
+                componentName: 'govukInput',
+                macroOptions: {
+                    label: {
+                        text: 'Event name'
+                    },
+                    hint: {
+                        text: "The name you'll use on promotional material."
+                    },
+                    id: 'event-name',
+                    name: 'event-name',
+                    type: 'text',
+                    classes: 'govuk-input--width-10'
+                }
+            };
+
+            expect(result).toEqual(expected);
+        });
+
+        it('should add "width-20" class if text input has maxLength more than or equal to 20 but less than 60', () => {
+            const result = qTransformer.transform({
+                schemaKey: 'event-name',
+                schema: {
+                    type: 'string',
+                    title: 'Event name',
+                    description: "The name you'll use on promotional material.",
+                    maxLength: 20
+                },
+                uiSchema: {}
+            });
+
+            const expected = {
+                id: 'event-name',
+                dependencies: ['{% from "input/macro.njk" import govukInput %}'],
+                componentName: 'govukInput',
+                macroOptions: {
+                    label: {
+                        text: 'Event name'
+                    },
+                    hint: {
+                        text: "The name you'll use on promotional material."
+                    },
+                    id: 'event-name',
+                    name: 'event-name',
+                    type: 'text',
+                    classes: 'govuk-input--width-20'
+                }
+            };
+
+            expect(result).toEqual(expected);
+        });
+
+        it('should add "width-30" class if text input has maxLength more than or equal to 60 but less than 500', () => {
+            const result = qTransformer.transform({
+                schemaKey: 'event-name',
+                schema: {
+                    type: 'string',
+                    title: 'Event name',
+                    description: "The name you'll use on promotional material.",
+                    maxLength: 60
+                },
+                uiSchema: {}
+            });
+
+            const expected = {
+                id: 'event-name',
+                dependencies: ['{% from "input/macro.njk" import govukInput %}'],
+                componentName: 'govukInput',
+                macroOptions: {
+                    label: {
+                        text: 'Event name'
+                    },
+                    hint: {
+                        text: "The name you'll use on promotional material."
+                    },
+                    id: 'event-name',
+                    name: 'event-name',
+                    type: 'text',
+                    classes: 'govuk-input--width-30'
+                }
+            };
+
+            expect(result).toEqual(expected);
+        });
+    });
 });

--- a/test/q-transformer.test.js
+++ b/test/q-transformer.test.js
@@ -252,10 +252,15 @@ describe('qTransformer', () => {
                             type: 'string',
                             format: 'date-time', // https://www.iso.org/iso-8601-date-and-time-format.html
                             title: 'When was your passport issued?',
-                            autoComplete: true, //  This will only have an affect if it is true. It is not necessary to include it if the answer is false.
                             description: 'For example, 12 11 2007'
                         },
-                        uiSchema: {}
+                        uiSchema: {
+                            'passport-issued': {
+                                options: {
+                                    autoComplete: true
+                                }
+                            }
+                        }
                     });
 
                     const expected = {
@@ -2079,8 +2084,14 @@ describe('qTransformer', () => {
                             format: 'email',
                             title: 'Email address'
                         }
-                    },
-                    context: 'summary'
+                    }
+                },
+                uiSchema: {
+                    'event-name': {
+                        options: {
+                            isSummary: true
+                        }
+                    }
                 }
             });
 

--- a/test/q-transformer.test.js
+++ b/test/q-transformer.test.js
@@ -128,7 +128,7 @@ describe('qTransformer', () => {
                 });
             });
 
-            describe('And a oneOf attribute', () => {
+            describe('And a oneOf attribute with fewer than 20 options', () => {
                 it('should convert it to a govukRadios instruction', () => {
                     const result = qTransformer.transform({
                         schemaKey: 'where-do-you-live',
@@ -290,6 +290,198 @@ describe('qTransformer', () => {
                                     classes: 'govuk-input--width-4',
                                     name: 'passport-issued[year]',
                                     autocomplete: 'bday-year'
+                                }
+                            ]
+                        }
+                    };
+
+                    expect(result).toEqual(expected);
+                });
+            });
+
+            describe('And a oneOf attribute with greater than 20 options', () => {
+                it('should convert it to a govukSelect instruction', () => {
+                    const result = qTransformer.transform({
+                        schemaKey: 'where-do-you-live',
+                        schema: {
+                            title: 'Where do you live?',
+                            type: 'string',
+                            oneOf: [
+                                {
+                                    const: 'england',
+                                    title: 'England'
+                                },
+                                {
+                                    const: 'scotland',
+                                    title: 'Scotland'
+                                },
+                                {
+                                    const: 'wales',
+                                    title: 'Wales'
+                                },
+                                {
+                                    const: 'northern-ireland',
+                                    title: 'Northern Ireland'
+                                },
+                                {
+                                    const: 'france',
+                                    title: 'France'
+                                },
+                                {
+                                    const: 'germany',
+                                    title: 'Germany'
+                                },
+                                {
+                                    const: 'spain',
+                                    title: 'Spain'
+                                },
+                                {
+                                    const: 'italy',
+                                    title: 'Italy'
+                                },
+                                {
+                                    const: 'switzerland',
+                                    title: 'Switzerland'
+                                },
+                                {
+                                    const: 'austria',
+                                    title: 'Austria'
+                                },
+                                {
+                                    const: 'poland',
+                                    title: 'Poland'
+                                },
+                                {
+                                    const: 'hungary',
+                                    title: 'Hungary'
+                                },
+                                {
+                                    const: 'netherlands',
+                                    title: 'Netherlands'
+                                },
+                                {
+                                    const: 'belgium',
+                                    title: 'Belgium'
+                                },
+                                {
+                                    const: 'denmark',
+                                    title: 'Denmark'
+                                },
+                                {
+                                    const: 'norway',
+                                    title: 'Norway'
+                                },
+                                {
+                                    const: 'sweden',
+                                    title: 'Sweden'
+                                },
+                                {
+                                    const: 'finland',
+                                    title: 'Finland'
+                                },
+                                {
+                                    const: 'croatia',
+                                    title: 'Croatia'
+                                },
+                                {
+                                    const: 'Czech Republic',
+                                    title: 'Czech Republic'
+                                }
+                            ]
+                        },
+                        uiSchema: {}
+                    });
+
+                    const expected = {
+                        id: 'where-do-you-live',
+                        dependencies: ['{% from "select/macro.njk" import govukSelect %}'],
+                        componentName: 'govukSelect',
+                        macroOptions: {
+                            name: 'where-do-you-live',
+                            label: {
+                                text: 'Where do you live?'
+                            },
+                            hint: null,
+                            items: [
+                                {
+                                    value: 'england',
+                                    text: 'England'
+                                },
+                                {
+                                    value: 'scotland',
+                                    text: 'Scotland'
+                                },
+                                {
+                                    value: 'wales',
+                                    text: 'Wales'
+                                },
+                                {
+                                    value: 'northern-ireland',
+                                    text: 'Northern Ireland'
+                                },
+                                {
+                                    value: 'france',
+                                    text: 'France'
+                                },
+                                {
+                                    value: 'germany',
+                                    text: 'Germany'
+                                },
+                                {
+                                    value: 'spain',
+                                    text: 'Spain'
+                                },
+                                {
+                                    value: 'italy',
+                                    text: 'Italy'
+                                },
+                                {
+                                    value: 'switzerland',
+                                    text: 'Switzerland'
+                                },
+                                {
+                                    value: 'austria',
+                                    text: 'Austria'
+                                },
+                                {
+                                    value: 'poland',
+                                    text: 'Poland'
+                                },
+                                {
+                                    value: 'hungary',
+                                    text: 'Hungary'
+                                },
+                                {
+                                    value: 'netherlands',
+                                    text: 'Netherlands'
+                                },
+                                {
+                                    value: 'belgium',
+                                    text: 'Belgium'
+                                },
+                                {
+                                    value: 'denmark',
+                                    text: 'Denmark'
+                                },
+                                {
+                                    value: 'norway',
+                                    text: 'Norway'
+                                },
+                                {
+                                    value: 'sweden',
+                                    text: 'Sweden'
+                                },
+                                {
+                                    value: 'finland',
+                                    text: 'Finland'
+                                },
+                                {
+                                    value: 'croatia',
+                                    text: 'Croatia'
+                                },
+                                {
+                                    value: 'Czech Republic',
+                                    text: 'Czech Republic'
                                 }
                             ]
                         }
@@ -1672,6 +1864,208 @@ describe('qTransformer', () => {
                     </form>`;
 
             expect(removeIndentation(result)).toEqual(removeIndentation(expected));
+        });
+
+        it('should display errors for govukSelect instruction', () => {
+            const result = qTransformer.transform({
+                schemaKey: 'where-do-you-live',
+                schema: {
+                    title: 'Where do you live?',
+                    type: 'string',
+                    description: 'Select all that apply.',
+                    oneOf: [
+                        {
+                            const: 'england',
+                            title: 'England'
+                        },
+                        {
+                            const: 'scotland',
+                            title: 'Scotland'
+                        },
+                        {
+                            const: 'wales',
+                            title: 'Wales'
+                        },
+                        {
+                            const: 'northern-ireland',
+                            title: 'Northern Ireland'
+                        },
+                        {
+                            const: 'france',
+                            title: 'France'
+                        },
+                        {
+                            const: 'germany',
+                            title: 'Germany'
+                        },
+                        {
+                            const: 'spain',
+                            title: 'Spain'
+                        },
+                        {
+                            const: 'italy',
+                            title: 'Italy'
+                        },
+                        {
+                            const: 'switzerland',
+                            title: 'Switzerland'
+                        },
+                        {
+                            const: 'austria',
+                            title: 'Austria'
+                        },
+                        {
+                            const: 'poland',
+                            title: 'Poland'
+                        },
+                        {
+                            const: 'hungary',
+                            title: 'Hungary'
+                        },
+                        {
+                            const: 'netherlands',
+                            title: 'Netherlands'
+                        },
+                        {
+                            const: 'belgium',
+                            title: 'Belgium'
+                        },
+                        {
+                            const: 'denmark',
+                            title: 'Denmark'
+                        },
+                        {
+                            const: 'norway',
+                            title: 'Norway'
+                        },
+                        {
+                            const: 'sweden',
+                            title: 'Sweden'
+                        },
+                        {
+                            const: 'finland',
+                            title: 'Finland'
+                        },
+                        {
+                            const: 'croatia',
+                            title: 'Croatia'
+                        },
+                        {
+                            const: 'Czech Republic',
+                            title: 'Czech Republic'
+                        }
+                    ]
+                },
+                uiSchema: {},
+                data: {
+                    'where-do-you-live': "something that doesn't match any of the items" // this should cause an error
+                },
+                schemaErrors: {
+                    'where-do-you-live': 'Please select an option'
+                }
+            });
+
+            const expected = {
+                id: 'where-do-you-live',
+                dependencies: ['{% from "select/macro.njk" import govukSelect %}'],
+                componentName: 'govukSelect',
+                macroOptions: {
+                    name: 'where-do-you-live',
+                    label: {
+                        text: 'Where do you live?'
+                    },
+                    hint: {
+                        text: 'Select all that apply.'
+                    },
+                    errorMessage: {
+                        text: 'Please select an option'
+                    },
+                    items: [
+                        {
+                            value: 'england',
+                            text: 'England'
+                        },
+                        {
+                            value: 'scotland',
+                            text: 'Scotland'
+                        },
+                        {
+                            value: 'wales',
+                            text: 'Wales'
+                        },
+                        {
+                            value: 'northern-ireland',
+                            text: 'Northern Ireland'
+                        },
+                        {
+                            value: 'france',
+                            text: 'France'
+                        },
+                        {
+                            value: 'germany',
+                            text: 'Germany'
+                        },
+                        {
+                            value: 'spain',
+                            text: 'Spain'
+                        },
+                        {
+                            value: 'italy',
+                            text: 'Italy'
+                        },
+                        {
+                            value: 'switzerland',
+                            text: 'Switzerland'
+                        },
+                        {
+                            value: 'austria',
+                            text: 'Austria'
+                        },
+                        {
+                            value: 'poland',
+                            text: 'Poland'
+                        },
+                        {
+                            value: 'hungary',
+                            text: 'Hungary'
+                        },
+                        {
+                            value: 'netherlands',
+                            text: 'Netherlands'
+                        },
+                        {
+                            value: 'belgium',
+                            text: 'Belgium'
+                        },
+                        {
+                            value: 'denmark',
+                            text: 'Denmark'
+                        },
+                        {
+                            value: 'norway',
+                            text: 'Norway'
+                        },
+                        {
+                            value: 'sweden',
+                            text: 'Sweden'
+                        },
+                        {
+                            value: 'finland',
+                            text: 'Finland'
+                        },
+                        {
+                            value: 'croatia',
+                            text: 'Croatia'
+                        },
+                        {
+                            value: 'Czech Republic',
+                            text: 'Czech Republic'
+                        }
+                    ]
+                }
+            };
+
+            expect(result).toEqual(expected);
         });
     });
 

--- a/test/q-transformer.test.js
+++ b/test/q-transformer.test.js
@@ -244,6 +244,59 @@ describe('qTransformer', () => {
 
                     expect(result).toEqual(expected);
                 });
+
+                it('should add the auto-complete class to the govUk object. ', () => {
+                    const result = qTransformer.transform({
+                        schemaKey: 'passport-issued',
+                        schema: {
+                            type: 'string',
+                            format: 'date-time', // https://www.iso.org/iso-8601-date-and-time-format.html
+                            title: 'When was your passport issued?',
+                            autoComplete: true, //  This will only have an affect if it is true. It is not necessary to include it if the answer is false.
+                            description: 'For example, 12 11 2007'
+                        },
+                        uiSchema: {}
+                    });
+
+                    const expected = {
+                        id: 'passport-issued',
+                        dependencies: ['{% from "date-input/macro.njk" import govukDateInput %}'],
+                        componentName: 'govukDateInput',
+                        macroOptions: {
+                            id: 'passport-issued',
+                            fieldset: {
+                                legend: {
+                                    text: 'When was your passport issued?'
+                                }
+                            },
+                            hint: {
+                                text: 'For example, 12 11 2007'
+                            },
+                            items: [
+                                {
+                                    label: 'Day',
+                                    classes: 'govuk-input--width-2',
+                                    name: 'passport-issued[day]',
+                                    autocomplete: 'bday-day'
+                                },
+                                {
+                                    label: 'Month',
+                                    classes: 'govuk-input--width-2',
+                                    name: 'passport-issued[month]',
+                                    autocomplete: 'bday-month'
+                                },
+                                {
+                                    label: 'Year',
+                                    classes: 'govuk-input--width-4',
+                                    name: 'passport-issued[year]',
+                                    autocomplete: 'bday-year'
+                                }
+                            ]
+                        }
+                    };
+
+                    expect(result).toEqual(expected);
+                });
             });
         });
 
@@ -1615,6 +1668,53 @@ describe('qTransformer', () => {
                         }) }}
                         {{ govukButton({
                             text: "Continue"
+                        }) }}
+                    </form>`;
+
+            expect(removeIndentation(result)).toEqual(removeIndentation(expected));
+        });
+    });
+
+    describe('Display the summary page', () => {
+        it('should display the accept and submit button', () => {
+            const result = qTransformer.transform({
+                schemaKey: 'event-name',
+                schema: {
+                    type: 'object',
+                    propertyNames: {
+                        enum: ['email', 'phone', 'text']
+                    },
+                    properties: {
+                        email: {
+                            type: 'string',
+                            description: 'e.g. something@something.com',
+                            format: 'email',
+                            title: 'Email address'
+                        }
+                    },
+                    context: 'summary'
+                }
+            });
+
+            const expected = `              
+                        <form method="post">
+                        {% from "button/macro.njk" import govukButton %}
+                        {% from "input/macro.njk" import govukInput %}
+                        {{ govukInput({
+                            "id": "email",
+                            "name": "email",
+                            "type": "email",
+                            "label": {
+                                "text": "Email address",
+                                "isPageHeading": true,
+                                "classes": "govuk-label--xl"
+                            },
+                            "hint": {
+                                "text": "e.g. something@something.com"
+                            }
+                        }) }}
+                        {{ govukButton({
+                            text: "Agree and Submit"
                         }) }}
                     </form>`;
 


### PR DESCRIPTION
This commit will add the auto-complete attribute to birthday fields, in compliance
with the govUk design standard.

This commit also adds functionality to change the default "continue" text on a
form button.