### PR TITLE
Add UAT fixes

### DIFF
--- a/lib/transformers/form.js
+++ b/lib/transformers/form.js
@@ -144,8 +144,7 @@ function form({schemaKey, schema, options, transform, data, schemaErrors} = {}) 
 
                     return toNunjucks(transformation.componentName, transformation.macroOptions);
                 })
-                .join('\n')}
-            `;
+                .join('\n')}`;
 }
 
 module.exports = form;

--- a/lib/transformers/govukInput.js
+++ b/lib/transformers/govukInput.js
@@ -10,7 +10,7 @@ module.exports = ({schemaKey, schema, options, data, schemaErrors} = {}) => {
             name: schemaKey,
             type: schema.format === 'email' ? 'email' : 'text',
             label: {
-                text: schema.title
+                html: schema.title
             },
             hint: schema.description ? {text: schema.description} : null
         }
@@ -37,12 +37,12 @@ module.exports = ({schemaKey, schema, options, data, schemaErrors} = {}) => {
         } else if (schema.maxLength >= 20 && schema.maxLength < 60) {
             // 50% field
             opts.macroOptions.classes = 'govuk-input--width-20';
-        }
-        // Greater than 60 will but less that 500 will return 75% field. Greater than 500 will render as a text area.
-        else {
+        } else if (schema.maxLength >= 60 && schema.maxLength <= 119) {
+            // 75% field
             opts.macroOptions.classes = 'govuk-input--width-30';
         }
-    }
+        // Greater than 59 but less that 120 will return 75% field. Greater than 500 will render as a text area.
+    } // Applying no classes will default to a 100% field.
 
     // Override defaults
     opts = merge(opts, options);

--- a/lib/transformers/govukTextarea.js
+++ b/lib/transformers/govukTextarea.js
@@ -9,7 +9,8 @@ module.exports = ({schemaKey, schema, options, data, schemaErrors} = {}) => {
             id: schemaKey,
             name: schemaKey,
             label: {
-                text: schema.title
+                text: schema.title,
+                classes: 'govuk-label govuk-label--l'
             },
             hint: schema.description ? {text: schema.description} : null
         }

--- a/lib/transformers/summary.js
+++ b/lib/transformers/summary.js
@@ -40,12 +40,12 @@ const summaryStructure = [
         title: 'Police report',
         questions: [
             'p--was-the-crime-reported-to-police',
+            'p--when-was-the-crime-reported-to-police',
+            'p--whats-the-crime-reference-number',
             'p--which-english-police-force-is-investigating-the-crime',
             'p--which-police-scotland-division-is-investigating-the-crime',
             'p--which-welsh-police-force-is-investigating-the-crime',
-            'p--when-was-the-crime-reported-to-police',
-            'p-applicant-select-reasons-for-the-delay-in-reporting-the-crime-to-police',
-            'p--whats-the-crime-reference-number'
+            'p-applicant-select-reasons-for-the-delay-in-reporting-the-crime-to-police'
         ]
     },
     {
@@ -67,7 +67,8 @@ module.exports = ({schemaKey, schema, options, data} = {}) => {
             if (answers[question]) {
                 const row = {
                     key: {
-                        text: schema.summaryInfo[question].displayName
+                        text: schema.summaryInfo[question].displayName,
+                        classes: 'govuk-!-width-one-half'
                     },
                     value: {
                         html: answers[question].value
@@ -98,7 +99,7 @@ module.exports = ({schemaKey, schema, options, data} = {}) => {
               ${summaryLists}
               <h2 class="govuk-heading-l">Agree and submit your application</h2>
               <p class="govuk-body">By submitting this application you agree that we can share the details in it with the police. This helps us get the police information that we need to make a decision.</p>
-              <p class="govuk-body">To find out more about how we handle your data <a class="govuk-body" href="https://www.gov.uk/guidance/cica-privacy-notice" target="">read our privacy notice</a>.</p>
+              <p class="govuk-body">To find out more about how we handle your data <a href="https://www.gov.uk/guidance/cica-privacy-notice" target="">read our privacy notice</a>.</p>
           `;
     const opts = merge(
         {

--- a/test/q-transformer.test.js
+++ b/test/q-transformer.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-identical-title */
 const createQTransformer = require('../lib/q-transformer');
 const defaultTransformer = require('../lib/transformers/default');
 const answerFormatHelper = require('../lib/helpers/answerHelper');
@@ -81,7 +82,7 @@ describe('qTransformer', () => {
                     componentName: 'govukInput',
                     macroOptions: {
                         label: {
-                            text: 'Event name'
+                            html: 'Event name'
                         },
                         hint: {
                             text: "The name you'll use on promotional material."
@@ -117,6 +118,7 @@ describe('qTransformer', () => {
                             name: 'more-detail',
                             id: 'more-detail',
                             label: {
+                                classes: 'govuk-label govuk-label--l',
                                 text: 'Can you provide more detail?'
                             },
                             hint: {
@@ -618,7 +620,7 @@ describe('qTransformer', () => {
                             "name": "email",
                             "type": "email",
                             "label": {
-                                "text": "Email address",
+                                "html": "Email address",
                                 "isPageHeading": true,
                                 "classes": "govuk-label--xl"
                             },
@@ -643,7 +645,7 @@ describe('qTransformer', () => {
                             "name": "phone",
                             "type": "text",
                             "label": {
-                                "text": "Phone number"
+                                "html": "Phone number"
                             },
                             "hint": null
                         }) }}
@@ -652,7 +654,7 @@ describe('qTransformer', () => {
                             "name": "text",
                             "type": "text",
                             "label": {
-                                "text": "Mobile phone number"
+                                "html": "Mobile phone number"
                             },
                             "hint": null
                         }) }}
@@ -703,7 +705,7 @@ describe('qTransformer', () => {
                             "name": "email",
                             "type": "email",
                             "label": {
-                                "text": "Email address"
+                                "html": "Email address"
                             },
                             "hint": {
                                 "text": "e.g. something@something.com"
@@ -795,7 +797,8 @@ describe('qTransformer', () => {
                                 rows: [
                                   {
                                     "key": {
-                                        "text": "Name"
+                                        "text": "Name",
+                                        "classes": "govuk-!-width-one-half"
                                     },
                                     "value": {
                                         "html": "Mr Barry Piccinni"
@@ -826,7 +829,7 @@ describe('qTransformer', () => {
                                 }) }}
                               <h2 class="govuk-heading-l">Agree and submit your application</h2>
                               <p class="govuk-body">By submitting this application you agree that we can share the details in it with the police. This helps us get the police information that we need to make a decision.</p>
-                              <p class="govuk-body">To find out more about how we handle your data <a class="govuk-body" href="https://www.gov.uk/guidance/cica-privacy-notice" target="">read our privacy notice</a>.</p>
+                              <p class="govuk-body">To find out more about how we handle your data <a href="https://www.gov.uk/guidance/cica-privacy-notice/" target="">read our privacy notice</a>.</p>
                             `
                 };
 
@@ -867,7 +870,8 @@ describe('qTransformer', () => {
                                 rows: [
                                   {
                                     "key": {
-                                        "text": "Name"
+                                        "text": "Name",
+                                        "classes": "govuk-!-width-one-half"
                                     },
                                     "value": {
                                         "html": "Mr Barry Piccinni"
@@ -889,7 +893,8 @@ describe('qTransformer', () => {
                                 rows: [
                                   {
                                     "key": {
-                                        "text": "When did the crime happen?"
+                                        "text": "When did the crime happen?",
+                                        "classes": "govuk-!-width-one-half"
                                     },
                                     "value": {
                                         "html": "01 January 2019"
@@ -916,7 +921,7 @@ describe('qTransformer', () => {
                                 }) }}
                               <h2 class="govuk-heading-l">Agree and submit your application</h2>
                               <p class="govuk-body">By submitting this application you agree that we can share the details in it with the police. This helps us get the police information that we need to make a decision.</p>
-                              <p class="govuk-body">To find out more about how we handle your data <a class="govuk-body" href="https://www.gov.uk/guidance/cica-privacy-notice" target="">read our privacy notice</a>.</p>
+                              <p class="govuk-body">To find out more about how we handle your data <a href="https://www.gov.uk/guidance/cica-privacy-notice" target="">read our privacy notice</a>.</p>
                             `
                 };
 
@@ -1065,7 +1070,7 @@ describe('qTransformer', () => {
                                                     "name": "email",
                                                     "type": "email",
                                                     "label": {
-                                                        "text": "Email address"
+                                                        "html": "Email address"
                                                     },
                                                     "hint": {
                                                         "text": "e.g. something@something.com"
@@ -1084,7 +1089,7 @@ describe('qTransformer', () => {
                                                     "name": "phone",
                                                     "type": "text",
                                                     "label": {
-                                                        "text": "Phone number"
+                                                        "html": "Phone number"
                                                     },
                                                     "hint": null
                                                 })
@@ -1101,7 +1106,7 @@ describe('qTransformer', () => {
                                                     "name": "text",
                                                     "type": "text",
                                                     "label": {
-                                                        "text": "Mobile phone number"
+                                                        "html": "Mobile phone number"
                                                     },
                                                     "hint": null
                                                 })
@@ -1244,7 +1249,7 @@ describe('qTransformer', () => {
                                                     "name": "email",
                                                     "type": "email",
                                                     "label": {
-                                                        "text": "Email address"
+                                                        "html": "Email address"
                                                     },
                                                     "hint": {
                                                         "text": "e.g. something@something.com"
@@ -1255,7 +1260,7 @@ describe('qTransformer', () => {
                                                     "name": "phone",
                                                     "type": "text",
                                                     "label": {
-                                                        "text": "Phone number"
+                                                        "html": "Phone number"
                                                     },
                                                     "hint": null
                                                 }),
@@ -1264,7 +1269,7 @@ describe('qTransformer', () => {
                                                     "name": "text",
                                                     "type": "text",
                                                     "label": {
-                                                        "text": "Mobile phone number"
+                                                        "html": "Mobile phone number"
                                                     },
                                                     "hint": null
                                                 })
@@ -1320,7 +1325,7 @@ describe('qTransformer', () => {
                         "name": "email",
                         "type": "email",
                         "label": {
-                            "text": "Email address",
+                            "html": "Email address",
                             "isPageHeading": true,
                             "classes": "govuk-label--xl"
                         },
@@ -1354,7 +1359,7 @@ describe('qTransformer', () => {
                 componentName: 'govukInput',
                 macroOptions: {
                     label: {
-                        text: 'Event name'
+                        html: 'Event name'
                     },
                     hint: {
                         text: "The name you'll use on promotional material."
@@ -1528,7 +1533,8 @@ describe('qTransformer', () => {
                     name: 'more-detail',
                     id: 'more-detail',
                     label: {
-                        text: 'Can you provide more detail?'
+                        text: 'Can you provide more detail?',
+                        classes: 'govuk-label govuk-label--l'
                     },
                     hint: {
                         text:
@@ -1621,7 +1627,7 @@ describe('qTransformer', () => {
                 componentName: 'govukInput',
                 macroOptions: {
                     label: {
-                        text: 'Event name'
+                        html: 'Event name'
                     },
                     hint: {
                         text: "The name you'll use on promotional material."
@@ -1854,7 +1860,8 @@ describe('qTransformer', () => {
                     name: 'more-detail',
                     id: 'more-detail',
                     label: {
-                        text: 'Can you provide more detail?'
+                        text: 'Can you provide more detail?',
+                        classes: 'govuk-label govuk-label--l'
                     },
                     errorMessage: {
                         text: 'Please enter more details'
@@ -1942,7 +1949,7 @@ describe('qTransformer', () => {
                             "name": "email",
                             "type": "email",
                             "label": {
-                                "text": "Email address",
+                                "html": "Email address",
                                 "isPageHeading": true,
                                 "classes": "govuk-label--xl"
                             },
@@ -1970,7 +1977,7 @@ describe('qTransformer', () => {
                             "name": "phone",
                             "type": "text",
                             "label": {
-                                "text": "Phone number"
+                                "html": "Phone number"
                             },
                             "hint": null,
                             "errorMessage": {
@@ -1982,7 +1989,7 @@ describe('qTransformer', () => {
                             "name": "text",
                             "type": "text",
                             "label": {
-                                "text": "Mobile phone number"
+                                "html": "Mobile phone number"
                             },
                             "hint": null
                         }) }}
@@ -2195,6 +2202,357 @@ describe('qTransformer', () => {
             };
 
             expect(result).toEqual(expected);
+        });
+    });
+
+    describe('Display text inputs with appropriate classes', () => {
+        it('should add "width-10" class if text input has maxLength less than 20', () => {
+            const result = qTransformer.transform({
+                schemaKey: 'event-name',
+                schema: {
+                    type: 'string',
+                    title: 'Event name',
+                    description: "The name you'll use on promotional material.",
+                    maxLength: 19
+                },
+                uiSchema: {}
+            });
+
+            const expected = {
+                id: 'event-name',
+                dependencies: ['{% from "input/macro.njk" import govukInput %}'],
+                componentName: 'govukInput',
+                macroOptions: {
+                    label: {
+                        html: 'Event name'
+                    },
+                    hint: {
+                        text: "The name you'll use on promotional material."
+                    },
+                    id: 'event-name',
+                    name: 'event-name',
+                    type: 'text',
+                    classes: 'govuk-input--width-10'
+                }
+            };
+
+            expect(result).toEqual(expected);
+        });
+
+        it('should add "width-20" class if text input has maxLength more than or equal to 20 but less than 60', () => {
+            const result = qTransformer.transform({
+                schemaKey: 'event-name',
+                schema: {
+                    type: 'string',
+                    title: 'Event name',
+                    description: "The name you'll use on promotional material.",
+                    maxLength: 20
+                },
+                uiSchema: {}
+            });
+
+            const expected = {
+                id: 'event-name',
+                dependencies: ['{% from "input/macro.njk" import govukInput %}'],
+                componentName: 'govukInput',
+                macroOptions: {
+                    label: {
+                        html: 'Event name'
+                    },
+                    hint: {
+                        text: "The name you'll use on promotional material."
+                    },
+                    id: 'event-name',
+                    name: 'event-name',
+                    type: 'text',
+                    classes: 'govuk-input--width-20'
+                }
+            };
+
+            expect(result).toEqual(expected);
+        });
+
+        it('should add "width-30" class if text input has maxLength more than or equal to 60 but less than 500', () => {
+            const result = qTransformer.transform({
+                schemaKey: 'event-name',
+                schema: {
+                    type: 'string',
+                    title: 'Event name',
+                    description: "The name you'll use on promotional material.",
+                    maxLength: 60
+                },
+                uiSchema: {}
+            });
+
+            const expected = {
+                id: 'event-name',
+                dependencies: ['{% from "input/macro.njk" import govukInput %}'],
+                componentName: 'govukInput',
+                macroOptions: {
+                    label: {
+                        html: 'Event name'
+                    },
+                    hint: {
+                        text: "The name you'll use on promotional material."
+                    },
+                    id: 'event-name',
+                    name: 'event-name',
+                    type: 'text',
+                    classes: 'govuk-input--width-30'
+                }
+            };
+
+            expect(result).toEqual(expected);
+        });
+    });
+
+    describe('Helper tests', () => {
+        let formattedAnswer = [];
+
+        describe('Answer helper', () => {
+            describe('Dynamic answer formatter', () => {
+                beforeAll(() => {
+                    const answerObject = {
+                        'p--start-now': {},
+                        'p-applicant-declaration': {},
+                        'p-applicant-british-citizen-or-eu-national': {
+                            'q-applicant-british-citizen-or-eu-national': 'true'
+                        },
+                        'p-applicant-are-you-18-or-over': {
+                            'q-applicant-are-you-18-or-over': 'true'
+                        },
+                        'p-applicant-who-are-you-applying-for': {
+                            'q-applicant-who-are-you-applying-for': 'myself'
+                        },
+                        'p-applicant-were-you-a-victim-of-sexual-assault-or-abuse': {
+                            'q-applicant-were-you-a-victim-of-sexual-assault-or-abuse': true
+                        },
+                        'p--before-you-continue': {},
+                        'p-applicant-select-the-option-that-applies-to-you': {
+                            'q-applicant-option': 'opt1'
+                        },
+                        'p--was-the-crime-reported-to-police': {
+                            'q-was-the-crime-reported-to-police': 'false'
+                        },
+                        'p--when-was-the-crime-reported-to-police': {
+                            'q--when-was-the-crime-reported-to-police': '2019-01-01T09:55:22.130Z'
+                        },
+                        'p-applicant-enter-your-name': {
+                            'q-applicant-name-title': 'Mr',
+                            'q-applicant-name-firstname': 'Barry',
+                            'q-applicant-name-lastname': 'Piccinni'
+                        },
+                        'p-applicant-enter-your-address': {
+                            'q-applicant-building-and-street': 'Alexander Bain House',
+                            'q-applicant-building-and-street2': 'Atlantic Quay',
+                            'q-applicant-town-or-city': 'Glasgow',
+                            'q-applicant-county': '',
+                            'q-applicant-postcode': 'G2 8JQ'
+                        }
+                    };
+                    formattedAnswer = answerFormatHelper.summaryFormatter(answerObject);
+                });
+
+                it('should format all responses into simple objects containing a value key and a href key', () => {
+                    // eslint-disable-next-line no-restricted-syntax
+                    for (const answer in formattedAnswer) {
+                        // eslint-disable-next-line no-prototype-builtins
+                        if (formattedAnswer.hasOwnProperty(answer)) {
+                            expect(Object.keys(formattedAnswer[answer])).toContain('value');
+                            expect(Object.keys(formattedAnswer[answer])).toContain('href');
+                        }
+                    }
+                });
+
+                it('should format all true/false answers to "Yes" or "No"', () => {
+                    const answerValues = [];
+                    // eslint-disable-next-line no-restricted-syntax
+                    for (const answer in formattedAnswer) {
+                        // eslint-disable-next-line no-prototype-builtins
+                        if (formattedAnswer.hasOwnProperty(answer)) {
+                            answerValues.push(formattedAnswer[answer].value);
+                        }
+                    }
+
+                    expect(answerValues).not.toContain('true');
+                    expect(answerValues).not.toContain('false');
+                    expect(answerValues).toContain('Yes');
+                    expect(answerValues).toContain('No');
+                });
+
+                it('should format a question with more than one but less than 4 answers on a single line', () => {
+                    expect(formattedAnswer['p-applicant-enter-your-name'].value).toMatch(
+                        'Mr Barry Piccinni'
+                    );
+                });
+
+                it('should format a question with 4 or more answers appears in a multi-line format', () => {
+                    expect(formattedAnswer['p-applicant-enter-your-address'].value).toMatch(
+                        'Alexander Bain House<br>Atlantic Quay<br>Glasgow<br>G2 8JQ'
+                    );
+                });
+
+                it('should correctly build the url for each question', () => {
+                    expect(formattedAnswer['p-applicant-enter-your-address'].href).toMatch(
+                        '/apply/applicant-enter-your-address?next=check-your-answers'
+                    );
+                    expect(formattedAnswer['p-applicant-enter-your-name'].href).toMatch(
+                        '/apply/applicant-enter-your-name?next=check-your-answers'
+                    );
+                    expect(
+                        formattedAnswer['p-applicant-were-you-a-victim-of-sexual-assault-or-abuse']
+                            .href
+                    ).toMatch(
+                        '/apply/applicant-were-you-a-victim-of-sexual-assault-or-abuse?next=check-your-answers'
+                    );
+                });
+            });
+            describe('Helper Methods', () => {
+                describe('isValidDate', () => {
+                    it('should return true is a valid date is entered', () => {
+                        const trueString = '2019-01-01T09:55:22.130Z';
+                        const falseString = 'not-a-date';
+
+                        const actual1 = answerFormatHelper.isValidDate(trueString);
+                        const actual2 = answerFormatHelper.isValidDate(falseString);
+
+                        expect(actual1).toBeTruthy();
+                        expect(actual2).not.toBeTruthy();
+                    });
+                });
+                describe('dateFormatter', () => {
+                    it('should return a date in a readable format', () => {
+                        const dateString = '2019-01-01T09:55:22.130Z';
+
+                        const actual = answerFormatHelper.dateFormatter(dateString);
+
+                        expect(actual).toMatch('01 January 2019');
+                    });
+                });
+                describe('textFormatter', () => {
+                    it('should return text in a readable format', () => {
+                        const inputString = 'i-am-an-answer';
+
+                        const actual = answerFormatHelper.textFormatter(inputString);
+
+                        expect(actual).toMatch('I am an answer');
+                    });
+                });
+                describe('multipleAnswersFormat', () => {
+                    describe('questions with more than 1 but less than 5 fields', () => {
+                        it('should return all fields except boolean on a single line separated by spaces', () => {
+                            const inputString = {
+                                'q-applicant-building-and-street': 'Alexander Bain House',
+                                'q-applicant-town-or-city': 'Glasgow',
+                                'q-applicant-postcode': 'G2 8JQ'
+                            };
+
+                            const actual = answerFormatHelper.multipleAnswersFormat(inputString);
+
+                            expect(actual).toMatch('Alexander Bain House Glasgow G2 8JQ');
+                        });
+
+                        it('should return boolean fields on a single comma separated line', () => {
+                            const inputString = {
+                                'q-do-you-live-in-glasgow': true,
+                                'q-applicant-town-or-city': 'Glasgow',
+                                'q-applicant-postcode': 'G2 8JQ'
+                            };
+
+                            const actual = answerFormatHelper.multipleAnswersFormat(inputString);
+
+                            expect(actual).toMatch('Yes, Glasgow G2 8JQ');
+                        });
+                    });
+
+                    describe('questions with more than 4 fields', () => {
+                        it('should return as a multi-row string', () => {
+                            const inputString = {
+                                'q-applicant-building-and-street': 'Alexander Bain House',
+                                'q-applicant-building-and-street2': 'Atlantic Quay',
+                                'q-applicant-town-or-city': 'Glasgow',
+                                'q-applicant-county': '',
+                                'q-applicant-postcode': 'G2 8JQ'
+                            };
+
+                            const actual = answerFormatHelper.multipleAnswersFormat(inputString);
+
+                            expect(actual).toMatch(
+                                'Alexander Bain House<br>Atlantic Quay<br>Glasgow<br>G2 8JQ'
+                            );
+                        });
+                    });
+                });
+            });
+            describe('arrayFormatter', () => {
+                it('should return all the elements of an array on a new line', () => {
+                    const inputArray = ['i-am-an-answer', 'another-answer', 'a-third-answer'];
+
+                    const actual = answerFormatHelper.arrayFormatter(inputArray);
+
+                    expect(actual).toMatch(
+                        'I am an answer<br>Another answer<br>A third answer<br>'
+                    );
+                });
+            });
+        });
+
+        describe('Police lookup', () => {
+            it('Should return the name of a police force given the index code.', () => {
+                const ayrshirePoliceIndex = 12157147;
+                const actual = policeLookup(ayrshirePoliceIndex);
+                const expected = 'Scotland Ayrshire';
+
+                expect(actual).toMatch(expected);
+            });
+        });
+    });
+
+    describe('Display the summary page', () => {
+        it('should display the accept and submit button', () => {
+            const result = qTransformer.transform({
+                schemaKey: 'event-name',
+                schema: {
+                    type: 'object',
+                    propertyNames: {
+                        enum: ['email', 'phone', 'text']
+                    },
+                    properties: {
+                        email: {
+                            type: 'string',
+                            description: 'e.g. something@something.com',
+                            format: 'email',
+                            title: 'Email address'
+                        }
+                    }
+                },
+                uiSchema: {
+                    'event-name': {
+                        options: {
+                            isSummary: true
+                        }
+                    }
+                }
+            });
+
+            const expected = `              
+                        {% from "input/macro.njk" import govukInput %}
+                        {{ govukInput({
+                            "id": "email",
+                            "name": "email",
+                            "type": "email",
+                            "label": {
+                                "text": "Email address",
+                                "isPageHeading": true,
+                                "classes": "govuk-label--xl"
+                            },
+                            "hint": {
+                                "text": "e.g. something@something.com"
+                            }
+                        }) }}
+                    `;
+
+            expect(removeIndentation(result)).toEqual(removeIndentation(expected));
         });
     });
 


### PR DESCRIPTION
This commit will add various fixes for bugs discovered in initial
UAT testing. These fixes include:
 - Changed the label 'text' key to 'html'
 - Altered the rules that govern the sizes of text input fields
 - Added the appropriate class to text area labels
 - Added a class to increase the first column width on the summary
 - Removed a class from a hyperlink on the summary