### PR TITLE
Add answer lookup

### DIFF
--- a/lib/helpers/answerHelper.js
+++ b/lib/helpers/answerHelper.js
@@ -27,31 +27,22 @@ function arrayFormatter(array) {
 function formatAnswer(answer) {
     const isADate = isValidDate(answer);
     const isArray = Array.isArray(answer);
-    switch (answer) {
-        case true: // If it's a true values
-        case 'true':
-            return 'Yes';
-        case false: // If it's a false value
-        case 'false':
-            return 'No';
-        default:
-            if (isADate) {
-                return dateFormatter(answer);
-            }
-            if (isArray) {
-                return arrayFormatter(answer);
-            }
-            if (typeof answer === 'number') {
-                const policeRef = policeLookup(answer);
-                if (policeRef) {
-                    return policeRef;
-                }
-            }
-            if (answerLookup(answer)) {
-                return answerLookup(answer);
-            }
-            return answer; // If it's a single value string
+    if (isADate) {
+        return dateFormatter(answer);
     }
+    if (isArray) {
+        return arrayFormatter(answer);
+    }
+    if (typeof answer === 'number') {
+        const policeRef = policeLookup(answer);
+        if (policeRef) {
+            return policeRef;
+        }
+    }
+    if (answerLookup(answer)) {
+        return answerLookup(answer);
+    }
+    return answer; // If it's a single value string
 }
 
 function multipleAnswersFormat(sectionObject) {
@@ -106,7 +97,7 @@ function summaryFormatter(answerObject, fullUiSchema) {
             }
         }
     });
-
+    console.log(JSON.stringify(answerIndex, null, 4));
     return answerIndex;
 }
 

--- a/lib/helpers/answerHelper.js
+++ b/lib/helpers/answerHelper.js
@@ -97,7 +97,6 @@ function summaryFormatter(answerObject, fullUiSchema) {
             }
         }
     });
-    console.log(JSON.stringify(answerIndex, null, 4));
     return answerIndex;
 }
 

--- a/lib/helpers/answerHelper.js
+++ b/lib/helpers/answerHelper.js
@@ -1,5 +1,6 @@
 const moment = require('moment');
 const policeLookup = require('./policeLookup');
+const answerLookup = require('./answerLookup');
 
 function removeSectionIdPrefix(sectionId) {
     return sectionId.replace(/p-{1,2}/, '');
@@ -54,7 +55,10 @@ function formatAnswer(answer) {
                     return policeRef;
                 }
             }
-            return textFormatter(answer); // If it's a single value string
+            if (answerLookup(answer)) {
+                return answerLookup(answer);
+            }
+            return answer; // If it's a single value string
     }
 }
 

--- a/lib/helpers/answerHelper.js
+++ b/lib/helpers/answerHelper.js
@@ -24,14 +24,6 @@ function arrayFormatter(array) {
     return returnValue;
 }
 
-function textFormatter(string) {
-    if (string === '') {
-        return '';
-    }
-
-    return string.replace(/-/g, ' ');
-}
-
 function formatAnswer(answer) {
     const isADate = isValidDate(answer);
     const isArray = Array.isArray(answer);
@@ -122,7 +114,6 @@ module.exports = {
     summaryFormatter,
     dateFormatter,
     isValidDate,
-    textFormatter,
     multipleAnswersFormat,
     arrayFormatter
 };

--- a/lib/helpers/answerLookup.js
+++ b/lib/helpers/answerLookup.js
@@ -1,5 +1,7 @@
 function lookupName(index) {
     const answerList = {
+        true: 'Yes',
+        false: 'No',
         once: 'Once',
         'over-a-period-of-time': 'Over a period of time',
         'i-was-underage': 'I was under 18',

--- a/lib/helpers/answerLookup.js
+++ b/lib/helpers/answerLookup.js
@@ -1,0 +1,25 @@
+function lookupName(index) {
+    const answerList = {
+        once: 'Once',
+        'over-a-period-of-time': 'Over a period of time',
+        'i-was-underage': 'I was under 18',
+        'i-was-advised-to-wait': 'I was advised to wait',
+        'medical-reasons': 'Medical reasons',
+        'other-reasons': 'Other reasons',
+        'i-was-under-18': 'I was under 18',
+        'unable-to-report-crime': 'Unable to report the crime',
+        other: 'Other reasons',
+        'option-1:-sexual-assault-or-abuse': 'Option 1: Sexual assault or abuse',
+        'option-2:-sexual-assault-or-abuse-and-other-injuries-or-losses':
+            'Option 2: Sexual assault or abuse and other injuries or losses',
+        myself: 'Myself',
+        'someone-else': 'Someone else',
+        england: 'England',
+        scotland: 'Scotland',
+        wales: 'Wales',
+        'somewhere-else': 'Somewhere else'
+    };
+    return answerList[index];
+}
+
+module.exports = lookupName;

--- a/test/q-transformer.test.js
+++ b/test/q-transformer.test.js
@@ -4,6 +4,7 @@ const defaultTransformer = require('../lib/transformers/default');
 const govukSelectTransformer = require('../lib/transformers/govukSelect');
 const answerFormatHelper = require('../lib/helpers/answerHelper');
 const policeLookup = require('../lib/helpers/policeLookup');
+const answerLookup = require('../lib/helpers/answerLookup');
 
 // Remove indentation from strings when comparing them
 function removeIndentation(val) {
@@ -3131,15 +3132,6 @@ describe('qTransformer', () => {
                         expect(actual).toMatch('01 January 2019');
                     });
                 });
-                describe('textFormatter', () => {
-                    it('should return text in a readable format', () => {
-                        const inputString = 'i-am-an-answer';
-
-                        const actual = answerFormatHelper.textFormatter(inputString);
-
-                        expect(actual).toMatch('i am an answer');
-                    });
-                });
                 describe('multipleAnswersFormat', () => {
                     describe('questions with more than 1 but less than 5 fields', () => {
                         it('should return all fields except boolean on a single line separated by spaces', () => {
@@ -3193,7 +3185,7 @@ describe('qTransformer', () => {
                     const actual = answerFormatHelper.arrayFormatter(inputArray);
 
                     expect(actual).toMatch(
-                        'i am an answer<br>another answer<br>a third answer<br>'
+                        'i-am-an-answer<br>another-answer<br>a-third-answer<br>'
                     );
                 });
             });
@@ -3204,6 +3196,16 @@ describe('qTransformer', () => {
                 const ayrshirePoliceIndex = 12157147;
                 const actual = policeLookup(ayrshirePoliceIndex);
                 const expected = 'Scotland Ayrshire';
+
+                expect(actual).toMatch(expected);
+            });
+        });
+
+        describe('Answer lookup', () => {
+            it('Should return the user friendly display name, given an answer ID.', () => {
+                const iWasUnder18AnswerId = 'i-was-under-18';
+                const actual = answerLookup(iWasUnder18AnswerId);
+                const expected = 'I was under 18';
 
                 expect(actual).toMatch(expected);
             });


### PR DESCRIPTION
This commit adds an answer lookup. This is used to obtain an user
friendly string to display on the summary, rather than the previous
method of altering the answer ID.