### PR TITLE
Output summary answers as text

### DIFF
--- a/lib/transformers/summary.js
+++ b/lib/transformers/summary.js
@@ -15,7 +15,7 @@ module.exports = ({schemaKey, schema, options, data, fullUiSchema} = {}) => {
                         classes: 'govuk-!-width-one-half'
                     },
                     value: {
-                        html: answers[question].value
+                        text: answers[question].value
                     },
                     actions: {
                         items: [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "q-transformer",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "description": "Transforms a questionnaire's JSON Schema in to a different format",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
The summary answers are being output as html instead of text. This bypasses nunjucks autoescaping feature and creates a possible XSS issue. This PR ensures the answers are output as espaced text.