### PR TITLE
Add offender contact in to lookup table

### DIFF
--- a/lib/helpers/answerLookup.js
+++ b/lib/helpers/answerLookup.js
@@ -19,7 +19,8 @@ function lookupName(index) {
         england: 'England',
         scotland: 'Scotland',
         wales: 'Wales',
-        'somewhere-else': 'Somewhere else'
+        'somewhere-else': 'Somewhere else',
+        'i-have-no-contact-with-the-offender': 'I have no contact with the offender'
     };
     return answerList[index];
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "q-transformer",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "description": "Transforms a questionnaire's JSON Schema in to a different format",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
On the `Check Your Answers` page the offender question is not being un-hyphenated.

This adds a human-friendly representation of the `i-have-no-contact-with-the-offender` answer value to the answer lookup table. 