### PR TITLE
Add additional mappings to radio transformer

### DIFF
--- a/lib/transformers/govukRadios.js
+++ b/lib/transformers/govukRadios.js
@@ -98,6 +98,16 @@ module.exports = ({schemaKey, schema, options, transformations, data, schemaErro
         });
     }
 
+    // Add additional mappings if present
+
+    if (opts.additionalMapping) {
+        opts.additionalMapping.forEach(item => {
+            const newMapping = {};
+            newMapping[item.itemType] = item.itemValue;
+            opts.macroOptions.items.splice(item.itemIndex, 0, newMapping);
+        });
+    }
+
     // Configure page heading
     if (opts.setPageHeading) {
         opts.macroOptions.fieldset.legend.isPageHeading = true;

--- a/test/q-transformer.test.js
+++ b/test/q-transformer.test.js
@@ -3912,4 +3912,102 @@ describe('qTransformer', () => {
             expect(result).toEqual(expected);
         });
     });
+
+    describe('Additional content', () => {
+        describe('Given a JSON Schema with type:object', () => {
+            describe('And a uiSchema with a "additionalMapping" attribute', () => {
+                it('should convert it to a govukRadios with additional content at the correct index', () => {
+                    const result = qTransformer.transform({
+                        schemaKey: 'p-some-id',
+                        schema: {
+                            type: 'object',
+                            properties: {
+                                contact: {
+                                    title: 'How would you prefer to be contacted?',
+                                    description: 'Select one option.',
+                                    type: 'string',
+                                    oneOf: [
+                                        {
+                                            title: 'Email',
+                                            const: 'email'
+                                        },
+                                        {
+                                            title: 'Phone',
+                                            const: 'phone'
+                                        },
+                                        {
+                                            title: 'Text message',
+                                            const: 'text'
+                                        }
+                                    ]
+                                }
+                            },
+                            required: ['contact']
+                        },
+                        uiSchema: {
+                            'p-some-id': {
+                                // transformer: 'form',
+                                options: {
+                                    properties: {
+                                        contact: {
+                                            // transformer: 'govukRadios',
+                                            options: {
+                                                additionalMapping: [
+                                                    {
+                                                        itemType: 'divider',
+                                                        itemValue: 'or',
+                                                        itemIndex: 2
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    });
+
+                    const expected = {
+                        pageTitle: 'How would you prefer to be contacted?',
+                        hasErrors: false,
+                        content: `
+                            {% from "radios/macro.njk" import govukRadios %}
+                            {{ govukRadios({
+                                "idPrefix": "contact",
+                                "name": "contact",
+                                "fieldset": {
+                                    "legend": {
+                                        "text": "How would you prefer to be contacted?",
+                                        "isPageHeading": true,
+                                        "classes": "govuk-fieldset__legend--xl"
+                                    }
+                                },
+                                "hint": {
+                                    "text": "Select one option."
+                                },
+                                "items": [
+                                    {
+                                        "value": "email",
+                                        "text": "Email"
+                                    },
+                                    {
+                                        "value": "phone",
+                                        "text": "Phone"
+                                    },
+                                    {
+                                        "divider": "or"
+                                    },
+                                    {
+                                        "value": "text",
+                                        "text": "Text message"
+                                    }
+                                ]
+                            }) }}`
+                    };
+
+                    expect(removeIndentation(result)).toEqual(removeIndentation(expected));
+                });
+            });
+        });
+    });
 });


### PR DESCRIPTION
This commit adds the ability to include additional components via the uiSchema. This is necessary to include elements such as dividers.