### PR TITLE
Update date input transformer condition

### DIFF
--- a/lib/transformers/default.js
+++ b/lib/transformers/default.js
@@ -43,7 +43,7 @@ module.exports = ({
             return govukSelect(args);
         }
 
-        if ('format' in schema && schema.format === 'date-time') {
+        if ('format' in schema && schema.format.startsWith('date-time')) {
             return govukDateInput(args);
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "q-transformer",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "q-transformer",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "description": "Transforms a questionnaire's JSON Schema in to a different format",
     "main": "index.js",
     "scripts": {

--- a/test/q-transformer.test.js
+++ b/test/q-transformer.test.js
@@ -903,6 +903,57 @@ describe('qTransformer', () => {
                 });
             });
 
+            describe('And a custom format attribute = "date"', () => {
+                it('should convert it to a govukDateInput instruction', () => {
+                    const result = qTransformer.transform({
+                        schemaKey: 'passport-issued',
+                        schema: {
+                            type: 'string',
+                            format: 'date-time--today-or-in-past',
+                            title: 'When was your passport issued?',
+                            description: 'For example, 12 11 2007'
+                        },
+                        uiSchema: {}
+                    });
+
+                    const expected = {
+                        id: 'passport-issued',
+                        dependencies: ['{% from "date-input/macro.njk" import govukDateInput %}'],
+                        componentName: 'govukDateInput',
+                        macroOptions: {
+                            id: 'passport-issued',
+                            fieldset: {
+                                legend: {
+                                    text: 'When was your passport issued?'
+                                }
+                            },
+                            hint: {
+                                text: 'For example, 12 11 2007'
+                            },
+                            items: [
+                                {
+                                    label: 'Day',
+                                    classes: 'govuk-input--width-2',
+                                    name: 'passport-issued[day]'
+                                },
+                                {
+                                    label: 'Month',
+                                    classes: 'govuk-input--width-2',
+                                    name: 'passport-issued[month]'
+                                },
+                                {
+                                    label: 'Year',
+                                    classes: 'govuk-input--width-4',
+                                    name: 'passport-issued[year]'
+                                }
+                            ]
+                        }
+                    };
+
+                    expect(result).toEqual(expected);
+                });
+            });
+
             describe('And a oneOf attribute with greater than 20 options', () => {
                 it('should convert it to a govukSelect instruction', () => {
                     const result = qTransformer.transform({


### PR DESCRIPTION
Change the if condition to be more flexible for date-time schema formats.
It now allows `date-time--today-or-in-past` and `date-time--in-past` formats to be rendered as a 3-box date input.