### PR TITLE
Add the additional properties feature to checkboxes

### DIFF
--- a/lib/transformers/govukCheckboxes.js
+++ b/lib/transformers/govukCheckboxes.js
@@ -88,6 +88,16 @@ module.exports = ({schemaKey, schema, options, transformations, data, schemaErro
         });
     }
 
+    // Add additional mappings if present
+
+    if (opts.additionalMapping) {
+        opts.additionalMapping.forEach(item => {
+            const newMapping = {};
+            newMapping[item.itemType] = item.itemValue;
+            opts.macroOptions.items.splice(item.itemIndex, 0, newMapping);
+        });
+    }
+
     // Configure page heading
     if (opts.setPageHeading) {
         opts.macroOptions.fieldset.legend.isPageHeading = true;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "q-transformer",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "q-transformer",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "Transforms a questionnaire's JSON Schema in to a different format",
     "main": "index.js",
     "scripts": {

--- a/test/q-transformer.test.js
+++ b/test/q-transformer.test.js
@@ -1163,6 +1163,88 @@ describe('qTransformer', () => {
 
                 expect(result).toEqual(expected);
             });
+
+            it('should convert it to a govukCheckboxes instruction with a divider', () => {
+                const result = qTransformer.transform({
+                    schemaKey: 'waste',
+                    schema: {
+                        title: 'Which types of waste do you transport?',
+                        description: 'Select all that apply.',
+                        type: 'array',
+                        items: {
+                            anyOf: [
+                                {
+                                    title: 'Waste from animal carcasses',
+                                    const: 'carcasses'
+                                },
+                                {
+                                    title: 'Waste from mines or quarries',
+                                    const: 'mines',
+                                    description: 'For example, coal mines'
+                                },
+                                {
+                                    title: 'Farm or agricultural waste',
+                                    const: 'farm'
+                                }
+                            ]
+                        }
+                    },
+                    uiSchema: {
+                        waste: {
+                            // transformer: 'govukCheckboxes',
+                            options: {
+                                additionalMapping: [
+                                    {
+                                        itemType: 'divider',
+                                        itemValue: 'or',
+                                        itemIndex: 2
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                });
+
+                const expected = {
+                    id: 'waste',
+                    dependencies: ['{% from "checkboxes/macro.njk" import govukCheckboxes %}'],
+                    componentName: 'govukCheckboxes',
+                    macroOptions: {
+                        idPrefix: 'waste',
+                        name: 'waste[]',
+                        fieldset: {
+                            legend: {
+                                text: 'Which types of waste do you transport?'
+                            }
+                        },
+                        hint: {
+                            text: 'Select all that apply.'
+                        },
+                        items: [
+                            {
+                                value: 'carcasses',
+                                text: 'Waste from animal carcasses'
+                            },
+                            {
+                                value: 'mines',
+                                text: 'Waste from mines or quarries',
+                                hint: {
+                                    text: 'For example, coal mines'
+                                }
+                            },
+                            {
+                                divider: 'or'
+                            },
+                            {
+                                value: 'farm',
+                                text: 'Farm or agricultural waste'
+                            }
+                        ]
+                    }
+                };
+
+                expect(result).toEqual(expected);
+            });
         });
 
         describe('Given a JSON Schema with type:object', () => {


### PR DESCRIPTION
This PR adds the 'additionalProperties' key to checkboxes. This allows us to use the UISchema to include the divider feature of the govuk frontend toolkit.

This PR also increases the version to v1.2.0

Automated testing has been added and passes

Manual testing has been also been carried out.