### PR TITLE
Autocompete autofill fixes

### DIFF
--- a/lib/transformers/govukCharacterCount.js
+++ b/lib/transformers/govukCharacterCount.js
@@ -38,11 +38,6 @@ module.exports = ({schemaKey, schema, options, data, schemaErrors} = {}) => {
         opts.macroOptions.label.classes = 'govuk-label--xl';
     }
 
-    if (opts.autoComplete) {
-        // add autocomplete to input fields
-        opts.macroOptions.autocomplete = opts.autoComplete;
-    }
-
     // transformation
     return {
         id: opts.id,

--- a/lib/transformers/govukDateInput.js
+++ b/lib/transformers/govukDateInput.js
@@ -22,6 +22,7 @@ module.exports = ({schemaKey, schema, options, data, schemaErrors} = {}) => {
                 {
                     label: 'Day',
                     classes: `govuk-input--width-2`,
+                    id: `${schemaKey}[day]`,
                     name: `${schemaKey}[day]`,
                     attributes: {
                         maxlength: '2'
@@ -30,6 +31,7 @@ module.exports = ({schemaKey, schema, options, data, schemaErrors} = {}) => {
                 {
                     label: 'Month',
                     classes: `govuk-input--width-2`,
+                    id: `${schemaKey}[month]`,
                     name: `${schemaKey}[month]`,
                     attributes: {
                         maxlength: '2'
@@ -38,6 +40,7 @@ module.exports = ({schemaKey, schema, options, data, schemaErrors} = {}) => {
                 {
                     label: 'Year',
                     classes: `govuk-input--width-4`,
+                    id: `${schemaKey}[year]`,
                     name: `${schemaKey}[year]`,
                     attributes: {
                         maxlength: '4'
@@ -69,10 +72,7 @@ module.exports = ({schemaKey, schema, options, data, schemaErrors} = {}) => {
 
     // Include errors
     if (opts.macroOptions.id in schemaErrors) {
-        // The gds govukDateInput prefixes each item with the id. Given the component has the id 'bla'
-        // The item inputs become "bla-bla[day]"
-        // Not sure how to stop that?
-        opts.errorSummaryHREF = `#${schemaKey}-${opts.macroOptions.items[0].name}`;
+        opts.errorSummaryHREF = `#${opts.macroOptions.items[0].name}`;
 
         opts.macroOptions.errorMessage = {
             text: schemaErrors[opts.macroOptions.id]
@@ -91,12 +91,17 @@ module.exports = ({schemaKey, schema, options, data, schemaErrors} = {}) => {
         opts.macroOptions.fieldset.legend.classes = 'govuk-fieldset__legend--xl';
     }
 
-    // Get only the date parts that should be displayed
-    opts.macroOptions.items = opts.macroOptions.items.filter(item => {
-        const datePart = item.label.toLowerCase();
+    if (opts.macroOptions.autocomplete) {
+        opts.macroOptions.items[0].autocomplete = `${options.macroOptions.autocomplete}-day`;
+        opts.macroOptions.items[1].autocomplete = `${options.macroOptions.autocomplete}-month`;
+        opts.macroOptions.items[2].autocomplete = `${options.macroOptions.autocomplete}-year`;
+        delete opts.macroOptions.autocomplete;
+    }
 
-        return opts.dateParts[datePart];
-    });
+    // Get only the date parts that should be displayed
+    opts.macroOptions.items = opts.macroOptions.items.filter(
+        item => opts.dateParts[item.label.toLowerCase()]
+    );
 
     // transformation
     const transformation = {
@@ -108,14 +113,6 @@ module.exports = ({schemaKey, schema, options, data, schemaErrors} = {}) => {
 
     if (opts.errorSummaryHREF) {
         transformation.errorSummaryHREF = opts.errorSummaryHREF;
-    }
-
-    if (opts.autoComplete) {
-        // add autocomplete to date fields. Only used for birthdays
-        opts.macroOptions.items.forEach(item => {
-            // eslint-disable-next-line no-param-reassign
-            item.autocomplete = `${opts.autoComplete}-${item.label.toLowerCase()}`;
-        });
     }
 
     return transformation;

--- a/lib/transformers/govukInput.js
+++ b/lib/transformers/govukInput.js
@@ -53,11 +53,6 @@ module.exports = ({schemaKey, schema, options, data, schemaErrors} = {}) => {
         opts.macroOptions.label.classes = 'govuk-label--xl';
     }
 
-    if (opts.autoComplete) {
-        // add autocomplete to input fields
-        opts.macroOptions.autocomplete = opts.autoComplete;
-    }
-
     // transformation
     return {
         id: opts.id,

--- a/lib/transformers/govukTextarea.js
+++ b/lib/transformers/govukTextarea.js
@@ -37,11 +37,6 @@ module.exports = ({schemaKey, schema, options, data, schemaErrors} = {}) => {
         opts.macroOptions.label.classes = 'govuk-label--xl';
     }
 
-    if (opts.autoComplete) {
-        // add autocomplete to input fields
-        opts.macroOptions.autocomplete = opts.autoComplete;
-    }
-
     // transformation
     return {
         id: opts.id,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "q-transformer",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "q-transformer",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "Transforms a questionnaire's JSON Schema in to a different format",
     "main": "index.js",
     "scripts": {

--- a/test/q-transformer.test.js
+++ b/test/q-transformer.test.js
@@ -178,7 +178,9 @@ describe('qTransformer', () => {
                 properties: {
                     'q-applicant-enter-your-date-of-birth': {
                         options: {
-                            autoComplete: true
+                            macroOptions: {
+                                autocomplete: true
+                            }
                         }
                     }
                 }
@@ -528,9 +530,11 @@ describe('qTransformer', () => {
                 properties: {
                     'q-applicant-enter-your-email-address': {
                         options: {
-                            autocomplete: 'email',
-                            attributes: {
-                                spellcheck: 'false'
+                            macroOptions: {
+                                autocomplete: 'email',
+                                attributes: {
+                                    spellcheck: 'false'
+                                }
                             }
                         }
                     }
@@ -622,7 +626,9 @@ describe('qTransformer', () => {
                         uiSchema: {
                             'passport-sent': {
                                 options: {
-                                    autoComplete: 'street-address'
+                                    macroOptions: {
+                                        autocomplete: 'street-address'
+                                    }
                                 }
                             }
                         }
@@ -701,7 +707,9 @@ describe('qTransformer', () => {
                         uiSchema: {
                             'more-detail': {
                                 options: {
-                                    autoComplete: 'street-address'
+                                    macroOptions: {
+                                        autocomplete: 'street-address'
+                                    }
                                 }
                             }
                         }
@@ -832,6 +840,7 @@ describe('qTransformer', () => {
                                     label: 'Day',
                                     classes: 'govuk-input--width-2',
                                     name: 'passport-issued[day]',
+                                    id: 'passport-issued[day]',
                                     attributes: {
                                         maxlength: '2'
                                     }
@@ -840,6 +849,7 @@ describe('qTransformer', () => {
                                     label: 'Month',
                                     classes: 'govuk-input--width-2',
                                     name: 'passport-issued[month]',
+                                    id: 'passport-issued[month]',
                                     attributes: {
                                         maxlength: '2'
                                     }
@@ -848,6 +858,7 @@ describe('qTransformer', () => {
                                     label: 'Year',
                                     classes: 'govuk-input--width-4',
                                     name: 'passport-issued[year]',
+                                    id: 'passport-issued[year]',
                                     attributes: {
                                         maxlength: '4'
                                     }
@@ -871,7 +882,9 @@ describe('qTransformer', () => {
                         uiSchema: {
                             'passport-issued': {
                                 options: {
-                                    autoComplete: 'bday'
+                                    macroOptions: {
+                                        autocomplete: 'bday'
+                                    }
                                 }
                             }
                         }
@@ -896,6 +909,7 @@ describe('qTransformer', () => {
                                     label: 'Day',
                                     classes: 'govuk-input--width-2',
                                     name: 'passport-issued[day]',
+                                    id: 'passport-issued[day]',
                                     autocomplete: 'bday-day',
                                     attributes: {
                                         maxlength: '2'
@@ -905,6 +919,7 @@ describe('qTransformer', () => {
                                     label: 'Month',
                                     classes: 'govuk-input--width-2',
                                     name: 'passport-issued[month]',
+                                    id: 'passport-issued[month]',
                                     autocomplete: 'bday-month',
                                     attributes: {
                                         maxlength: '2'
@@ -914,6 +929,7 @@ describe('qTransformer', () => {
                                     label: 'Year',
                                     classes: 'govuk-input--width-4',
                                     name: 'passport-issued[year]',
+                                    id: 'passport-issued[year]',
                                     autocomplete: 'bday-year',
                                     attributes: {
                                         maxlength: '4'
@@ -3559,6 +3575,7 @@ describe('qTransformer', () => {
                             label: 'Day',
                             classes: 'govuk-input--width-2',
                             name: 'passport-issued[day]',
+                            id: 'passport-issued[day]',
                             value: 1,
                             attributes: {
                                 maxlength: '2'
@@ -3568,6 +3585,7 @@ describe('qTransformer', () => {
                             label: 'Month',
                             classes: 'govuk-input--width-2',
                             name: 'passport-issued[month]',
+                            id: 'passport-issued[month]',
                             value: 2,
                             attributes: {
                                 maxlength: '2'
@@ -3577,6 +3595,7 @@ describe('qTransformer', () => {
                             label: 'Year',
                             classes: 'govuk-input--width-4',
                             name: 'passport-issued[year]',
+                            id: 'passport-issued[year]',
                             value: 1980,
                             attributes: {
                                 maxlength: '4'
@@ -3806,7 +3825,7 @@ describe('qTransformer', () => {
 
             const expected = {
                 id: 'event-name',
-                errorSummaryHREF: '#event-name-event-name[day]',
+                errorSummaryHREF: '#event-name[day]',
                 dependencies: ['{% from "date-input/macro.njk" import govukDateInput %}'],
                 componentName: 'govukDateInput',
                 macroOptions: {
@@ -3827,6 +3846,7 @@ describe('qTransformer', () => {
                             label: 'Day',
                             classes: 'govuk-input--width-2 govuk-input--error',
                             name: 'event-name[day]',
+                            id: 'event-name[day]',
                             value: 0,
                             attributes: {
                                 maxlength: '2'
@@ -3836,6 +3856,7 @@ describe('qTransformer', () => {
                             label: 'Month',
                             classes: 'govuk-input--width-2 govuk-input--error',
                             name: 'event-name[month]',
+                            id: 'event-name[month]',
                             value: 0,
                             attributes: {
                                 maxlength: '2'
@@ -3845,6 +3866,7 @@ describe('qTransformer', () => {
                             label: 'Year',
                             classes: 'govuk-input--width-4 govuk-input--error',
                             name: 'event-name[year]',
+                            id: 'event-name[year]',
                             value: 0,
                             attributes: {
                                 maxlength: '4'


### PR DESCRIPTION
Removes custom `autoComplete` property in favour of using the in-built `autocomplete` macro option implemented in the GOVUK frontend nunjucks templates