### PR TITLE
Add basic 'allOf' schema support

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,4 +7,3 @@ const config = {
 /*! m0-start */
 module.exports = config;
 /*! m0-end */
-

--- a/lib/transformers/allOf.js
+++ b/lib/transformers/allOf.js
@@ -1,0 +1,127 @@
+const merge = require('lodash.merge');
+const createNunjucksHelper = require('../helpers/nunjucks');
+
+const nunjucksHelper = createNunjucksHelper();
+
+function getNunjucksImports(transformations) {
+    const dependencies = new Set();
+
+    Object.keys(transformations).forEach(id => {
+        const transformation = transformations[id];
+
+        transformation.dependencies.forEach(dependency => dependencies.add(dependency));
+    });
+
+    return Array.from(dependencies);
+}
+
+function generateErrorSummary(transformationOrder, transformations) {
+    const errors = transformationOrder.reduce((acc, property) => {
+        const transformation = transformations[property];
+
+        if ('macroOptions' in transformation && 'errorMessage' in transformation.macroOptions) {
+            const errorObj = {
+                href: `#${transformation.macroOptions.name}`,
+                text: transformation.macroOptions.errorMessage.text
+            };
+
+            // Some inputs consist of multiple things e.g. radios, checkboxes, dates
+            // These inputs will set their own error summary href to correspond with their first item
+            if (transformation.errorSummaryHREF) {
+                errorObj.href = transformation.errorSummaryHREF;
+            }
+
+            acc.push(errorObj);
+        }
+
+        return acc;
+    }, []);
+
+    return errors.length
+        ? `{% from "error-summary/macro.njk" import govukErrorSummary %}
+              {{ govukErrorSummary({
+                titleText: "There is a problem",
+                errorList: ${JSON.stringify(errors, null, 4)}}) }}`
+        : '';
+}
+
+function allOf({schema, options, transform, data, schemaErrors} = {}) {
+    const opts = merge({}, options);
+    const groupSchema = schema.allOf[0];
+    const pageHeading = groupSchema.title;
+
+    // Transform sub schemas
+    const transformations = groupSchema.allOf.reduce((acc, propertiesSchema) => {
+        const {properties} = propertiesSchema;
+
+        // Transform sub schemas
+        Object.keys(properties).forEach(subSchemaKey => {
+            const subSchema = properties[subSchemaKey];
+            let subUISchema = {};
+
+            // Is there a sub uiSchema
+            if (options && 'properties' in options && subSchemaKey in options.properties) {
+                subUISchema = merge(subUISchema, {
+                    [subSchemaKey]: options.properties[subSchemaKey]
+                });
+            }
+
+            // Do transform. Pass in all transformations thus far.
+            const transformation = transform({
+                schemaKey: subSchemaKey,
+                schema: subSchema,
+                uiSchema: subUISchema,
+                transformations: acc,
+                data,
+                schemaErrors
+            });
+
+            acc[subSchemaKey] = transformation;
+        });
+
+        return acc;
+    }, {});
+
+    opts.outputOrder = opts.outputOrder || Object.keys(transformations);
+    opts.transformOrder = opts.transformOrder || opts.outputOrder;
+
+    const nunjucksImports = getNunjucksImports(transformations);
+
+    const order = [...new Set([...opts.outputOrder, ...opts.transformOrder])];
+
+    const summaryText = generateErrorSummary(order, transformations);
+
+    return {
+        content: `${summaryText}
+            ${nunjucksImports.join('\n')}
+            {% from "fieldset/macro.njk" import govukFieldset %}
+            {% call govukFieldset({
+                legend: {
+                  html: "${pageHeading}",
+                  classes: "govuk-fieldset__legend--xl",
+                  isPageHeading: true
+                }
+            }) %}
+            ${opts.outputOrder
+                .map(property => {
+                    const transformation = transformations[property];
+                    if (
+                        transformation.componentName === 'rawContent' ||
+                        transformation.componentName === 'summary'
+                    ) {
+                        return transformation.content;
+                    }
+
+                    return nunjucksHelper.toNunjucks(
+                        transformation.componentName,
+                        transformation.macroOptions
+                    );
+                })
+                .join('\n')}
+            {% endcall %}`,
+        pageTitle: pageHeading,
+        hasErrors: !!summaryText
+    };
+}
+
+module.exports = allOf;

--- a/lib/transformers/default.js
+++ b/lib/transformers/default.js
@@ -7,6 +7,7 @@ const form = require('./form');
 const govukSelect = require('./govukSelect');
 const summary = require('./summary');
 const govukCharacterCount = require('./govukCharacterCount');
+const allOf = require('./allOf');
 
 // TODO: Tidy these args up e.g. duplicated in function body
 module.exports = ({
@@ -66,7 +67,14 @@ module.exports = ({
         if ('properties' in schema && 'summaryInfo' in schema.properties) {
             return summary(args);
         }
-        return form(args);
+
+        if ('properties' in schema) {
+            return form(args);
+        }
+
+        if ('allOf' in schema) {
+            return allOf(args);
+        }
     }
 
     if (schema.type === 'boolean') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "q-transformer",
-    "version": "3.3.1",
+    "version": "3.4.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "q-transformer",
-    "version": "3.3.1",
+    "version": "3.4.0",
     "description": "Transforms a questionnaire's JSON Schema in to a different format",
     "main": "index.js",
     "scripts": {

--- a/test/allof.test.js
+++ b/test/allof.test.js
@@ -1,0 +1,153 @@
+const createQTransformer = require('../lib/q-transformer');
+const defaultTransformer = require('../lib/transformers/default');
+
+// Remove indentation from strings when comparing them
+function removeIndentation(val) {
+    const regex = /^\s+/gm;
+
+    if (val && typeof val === 'object' && !Array.isArray(val)) {
+        return JSON.parse(
+            JSON.stringify(val, (key, value) => {
+                if (typeof value === 'string') {
+                    return value.replace(regex, '');
+                }
+
+                return value;
+            })
+        );
+    }
+
+    return val.replace(regex, '');
+}
+
+describe('allOf', () => {
+    let qTransformer;
+
+    beforeEach(() => {
+        qTransformer = createQTransformer({
+            default: defaultTransformer
+        });
+    });
+
+    describe('Defaults', () => {
+        describe('Given a JSON Schema with type:object', () => {
+            describe('And the "allOf" keyword is present with no "properties" keyword', () => {
+                it('should render a nunjucks representation of a form with a nested allOf', () => {
+                    const result = qTransformer.transform({
+                        schemaKey: 'p-applicant-enter-your-name',
+                        schema: {
+                            $schema: 'http://json-schema.org/draft-07/schema#',
+                            type: 'object',
+                            allOf: [
+                                {
+                                    required: [
+                                        'q-applicant-title',
+                                        'q-applicant-first-name',
+                                        'q-applicant-last-name'
+                                    ],
+                                    title: 'Enter your name',
+                                    allOf: [
+                                        {
+                                            properties: {
+                                                'q-applicant-title': {
+                                                    title: 'Title',
+                                                    type: 'string',
+                                                    maxLength: 6,
+                                                    errorMessage: {
+                                                        maxLength:
+                                                            'Title must be 6 characters or less'
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            properties: {
+                                                'q-applicant-first-name': {
+                                                    title: 'First name',
+                                                    type: 'string',
+                                                    maxLength: 70,
+                                                    errorMessage: {
+                                                        maxLength:
+                                                            'First name must be 70 characters or less'
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            properties: {
+                                                'q-applicant-last-name': {
+                                                    title: 'Last name',
+                                                    type: 'string',
+                                                    maxLength: 70,
+                                                    errorMessage: {
+                                                        maxLength:
+                                                            'Last name must be 70 characters or less'
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    errorMessage: {
+                                        required: {
+                                            'q-applicant-title': 'Enter your title',
+                                            'q-applicant-first-name': 'Enter your first name',
+                                            'q-applicant-last-name': 'Enter your last name'
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        uiSchema: {}
+                    });
+
+                    const expected = {
+                        pageTitle: 'Enter your name',
+                        hasErrors: false,
+                        content: `{% from "input/macro.njk" import govukInput %}
+                            {% from "fieldset/macro.njk" import govukFieldset %}
+                            {% call govukFieldset({
+                                legend: {
+                                    html: "Enter your name",
+                                    classes: "govuk-fieldset__legend--xl",
+                                    isPageHeading: true
+                                }
+                            }) %}
+                                {{ govukInput({
+                                    "id": "q-applicant-title",
+                                    "name": "q-applicant-title",
+                                    "type": "text",
+                                    "label": {
+                                        "html": "Title"
+                                    },
+                                    "hint": null,
+                                    "classes": "govuk-input--width-10"
+                                }) }}
+                                {{ govukInput({
+                                    "id": "q-applicant-first-name",
+                                    "name": "q-applicant-first-name",
+                                    "type": "text",
+                                    "label": {
+                                        "html": "First name"
+                                    },
+                                    "hint": null,
+                                    "classes": "govuk-input--width-30"
+                                }) }}
+                                {{ govukInput({
+                                    "id": "q-applicant-last-name",
+                                    "name": "q-applicant-last-name",
+                                    "type": "text",
+                                    "label": {
+                                        "html": "Last name"
+                                    },
+                                    "hint": null,
+                                    "classes": "govuk-input--width-30"
+                                }) }}
+                            {% endcall %}`
+                    };
+
+                    expect(removeIndentation(result)).toEqual(removeIndentation(expected));
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Allows the _basic_ use of 'allOf' in schemas. Gives a mechanism for grouping related things and allows them to be wrapped in an html fieldset element.

All tests passing.