### PR TITLE
Add support for one-checkbox declaration-style schemas

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,8 @@ const config = {
         'prettier/prettier': ['error'],
         'linebreak-style': ['error', process.platform === 'win32' ? 'windows' : 'unix'],
         'curly': ['error', 'all'],
-        'jest/expect-expect': ['error']
+        'jest/expect-expect': ['error'],
+        'no-param-reassign': ['error', {props: false}]
     },
     plugins: ['prettier']
 };

--- a/lib/helpers/string/index.js
+++ b/lib/helpers/string/index.js
@@ -1,0 +1,11 @@
+function createStringHelper() {
+    function containsHtml(str) {
+        return /<\/?[a-z][\s\S]*>/i.test(str);
+    }
+
+    return Object.freeze({
+        containsHtml
+    });
+}
+
+module.exports = createStringHelper;

--- a/lib/transformers/allOf.js
+++ b/lib/transformers/allOf.js
@@ -76,6 +76,12 @@ function allOf({schema, options, transform, data, schemaErrors} = {}) {
                 schemaErrors
             });
 
+            if (transformation.macroOptions && transformation.macroOptions.fieldset) {
+                // `allOf` transformer wraps everything in a fieldset. remove the
+                // config for nested fieldset with the "sub" transformation.
+                delete transformation.macroOptions.fieldset;
+            }
+
             acc[subSchemaKey] = transformation;
         });
 

--- a/lib/transformers/default.js
+++ b/lib/transformers/default.js
@@ -37,9 +37,9 @@ module.exports = ({
         }
 
         if ('oneOf' in schema) {
-            if (schema.oneOf.length === 1) {
-                return govukCheckboxes(args);
-            }
+            // if (schema.oneOf.length === 1) {
+            //     return govukCheckboxes(args);
+            // }
 
             if (schema.oneOf.length < 20) {
                 return govukRadios(args);
@@ -49,6 +49,10 @@ module.exports = ({
 
         if ('format' in schema && schema.format === 'date-time') {
             return govukDateInput(args);
+        }
+
+        if ('const' in schema) {
+            return govukCheckboxes(args);
         }
 
         return govukInput(args);

--- a/lib/transformers/default.js
+++ b/lib/transformers/default.js
@@ -37,6 +37,10 @@ module.exports = ({
         }
 
         if ('oneOf' in schema) {
+            if (schema.oneOf.length === 1) {
+                return govukCheckboxes(args);
+            }
+
             if (schema.oneOf.length < 20) {
                 return govukRadios(args);
             }

--- a/lib/transformers/govukCheckboxes.js
+++ b/lib/transformers/govukCheckboxes.js
@@ -19,8 +19,6 @@ module.exports = ({schemaKey, schema, options, transformations, data, schemaErro
         }
     };
 
-    if there is one item, then do not render a fieldset - remove it from the opts.
-
     const stringHelper = createStringHelper();
     // Setup items
     opts.macroOptions.items = schema.items.anyOf.map(subSchema => {

--- a/lib/transformers/govukCheckboxes.js
+++ b/lib/transformers/govukCheckboxes.js
@@ -26,7 +26,7 @@ module.exports = ({schemaKey, schema, options, transformations, data, schemaErro
     // If there is only 1 item in the schema, then this cannot be mutually
     // excluded from another as it is non-existent. Use the checkbox transformer
     // here instead to maintain that binary mutual exclusivity.
-    if (schema.oneOf.length === 1) {
+    if (schema.oneOf && schema.oneOf.length === 1) {
         schema.items = {
             anyOf: schema.oneOf
         };

--- a/lib/transformers/govukCheckboxes.js
+++ b/lib/transformers/govukCheckboxes.js
@@ -19,6 +19,8 @@ module.exports = ({schemaKey, schema, options, transformations, data, schemaErro
         }
     };
 
+    if there is one item, then do not render a fieldset - remove it from the opts.
+
     const stringHelper = createStringHelper();
     // Setup items
     opts.macroOptions.items = schema.items.anyOf.map(subSchema => {

--- a/lib/transformers/govukCheckboxes.js
+++ b/lib/transformers/govukCheckboxes.js
@@ -26,9 +26,14 @@ module.exports = ({schemaKey, schema, options, transformations, data, schemaErro
     // If there is only 1 item in the schema, then this cannot be mutually
     // excluded from another as it is non-existent. Use the checkbox transformer
     // here instead to maintain that binary mutual exclusivity.
-    if (schema.oneOf && schema.oneOf.length === 1) {
+    if (schema.const) {
         schema.items = {
-            anyOf: schema.oneOf
+            anyOf: [
+                {
+                    title: schema.title,
+                    const: schema.const
+                }
+            ]
         };
         delete schema.oneOf;
         // need to be a string.Remove the `[]` from the name defined above.

--- a/lib/transformers/govukCheckboxes.js
+++ b/lib/transformers/govukCheckboxes.js
@@ -19,6 +19,22 @@ module.exports = ({schemaKey, schema, options, transformations, data, schemaErro
         }
     };
 
+    // deal with the edge case where we need to pre-process
+    // some arguments to fit to the expected checkbox-friendly shape.
+    // `oneOf` is typically used to represent multiple mutually exclusive
+    // options. For example, radio buttons, or a select boxes.
+    // If there is only 1 item in the schema, then this cannot be mutually
+    // excluded from another as it is non-existent. Use the checkbox transformer
+    // here instead to maintain that binary mutually exclusivity.
+    if (schema.oneOf.length === 1) {
+        schema.items = {
+            anyOf: schema.oneOf
+        };
+        delete schema.oneOf;
+        // need to be a string.Remove the `[]` from the name defined above.
+        opts.macroOptions.name = schemaKey;
+    }
+
     const stringHelper = createStringHelper();
     // Setup items
     opts.macroOptions.items = schema.items.anyOf.map(subSchema => {

--- a/lib/transformers/govukCheckboxes.js
+++ b/lib/transformers/govukCheckboxes.js
@@ -25,7 +25,7 @@ module.exports = ({schemaKey, schema, options, transformations, data, schemaErro
     // options. For example, radio buttons, or a select boxes.
     // If there is only 1 item in the schema, then this cannot be mutually
     // excluded from another as it is non-existent. Use the checkbox transformer
-    // here instead to maintain that binary mutually exclusivity.
+    // here instead to maintain that binary mutual exclusivity.
     if (schema.oneOf.length === 1) {
         schema.items = {
             anyOf: schema.oneOf

--- a/lib/transformers/govukCheckboxes.js
+++ b/lib/transformers/govukCheckboxes.js
@@ -1,4 +1,5 @@
 const merge = require('lodash.merge');
+const createStringHelper = require('../helpers/string');
 
 module.exports = ({schemaKey, schema, options, transformations, data, schemaErrors} = {}) => {
     let opts = {
@@ -18,12 +19,18 @@ module.exports = ({schemaKey, schema, options, transformations, data, schemaErro
         }
     };
 
+    const stringHelper = createStringHelper();
     // Setup items
     opts.macroOptions.items = schema.items.anyOf.map(subSchema => {
         const item = {
-            value: subSchema.const,
-            text: subSchema.title
+            value: subSchema.const
         };
+
+        if (stringHelper.containsHtml(subSchema.title)) {
+            item.html = subSchema.title;
+        } else {
+            item.text = subSchema.title;
+        }
 
         if (subSchema.description) {
             item.hint = {

--- a/test/allof.test.js
+++ b/test/allof.test.js
@@ -147,6 +147,85 @@ describe('allOf', () => {
 
                     expect(removeIndentation(result)).toEqual(removeIndentation(expected));
                 });
+
+                it('should render a nunjucks representation of a form with no nested fieldset elements', () => {
+                    const result = qTransformer.transform({
+                        schemaKey: 'p-applicant-declaration',
+                        schema: {
+                            $schema: 'http://json-schema.org/draft-07/schema#',
+                            type: 'object',
+                            allOf: [
+                                {
+                                    title: 'Declaration',
+                                    required: ['q-applicant-declaration'],
+                                    propertyNames: {
+                                        enum: ['applicant-declaration', 'q-applicant-declaration']
+                                    },
+                                    allOf: [
+                                        {
+                                            properties: {
+                                                'applicant-declaration': {
+                                                    description: '<div id="declaration">blah</div>'
+                                                }
+                                            }
+                                        },
+                                        {
+                                            properties: {
+                                                'q-applicant-declaration': {
+                                                    type: 'array',
+                                                    items: {
+                                                        anyOf: [
+                                                            {
+                                                                title:
+                                                                    'I have read and agree with the <a href="#declaration" class="govuk-link">declaration</a>',
+                                                                const: 'i-agree'
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    errorMessage: {
+                                        required: {
+                                            'q-applicant-declaration': 'Select that you agree'
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        uiSchema: {}
+                    });
+
+                    const expected = {
+                        hasErrors: false,
+                        pageTitle: 'Declaration',
+                        content: `{% from "checkboxes/macro.njk" import govukCheckboxes %}
+                            {% from "fieldset/macro.njk" import govukFieldset %}
+                            {% call govukFieldset({
+                                legend: {
+                                html: "Declaration",
+                                classes: "govuk-fieldset__legend--xl",
+                                isPageHeading: true
+                                }
+                            }) %}
+                            <div id="declaration">blah</div>
+                            {{ govukCheckboxes({
+                                "idPrefix": "q-applicant-declaration",
+                                "name": "q-applicant-declaration[]",
+                                "hint": null,
+                                "items": [
+                                    {
+                                        "value": "i-agree",
+                                        "html": "I have read and agree with the <a href=\\"#declaration\\" class=\\"govuk-link\\">declaration</a>"
+                                    }
+                                ]
+                            }) }}
+                        {% endcall %}`
+                    };
+
+                    expect(removeIndentation(result)).toEqual(removeIndentation(expected));
+                });
             });
         });
     });

--- a/test/q-transformer.test.js
+++ b/test/q-transformer.test.js
@@ -2387,6 +2387,10 @@ describe('qTransformer', () => {
                                             {
                                                 title: 'Email',
                                                 const: 'email'
+                                            },
+                                            {
+                                                title: 'Text',
+                                                const: 'text'
                                             }
                                         ]
                                     },
@@ -2485,6 +2489,10 @@ describe('qTransformer', () => {
                                         "conditional": {
                                             "html": ([this_id_cant_be_used_as_a_variable_identifier_as_it_contains_hyphens_email] | join())
                                         }
+                                    },
+                                    {
+                                        "value": "text",
+                                        "text": "Text"
                                     }
                                 ],
                                 "classes": "govuk-radios--inline"

--- a/test/q-transformer.test.js
+++ b/test/q-transformer.test.js
@@ -3088,6 +3088,10 @@ describe('qTransformer', () => {
                                                 {
                                                     title: 'Email',
                                                     const: 'email'
+                                                },
+                                                {
+                                                    title: 'SMS',
+                                                    const: 'text'
                                                 }
                                             ]
                                         }
@@ -3188,6 +3192,10 @@ describe('qTransformer', () => {
                                         "conditional": {
                                             "html": ([this_id_cant_be_used_as_a_variable_identifier_as_it_contains_hyphens_email] | join())
                                         }
+                                    },
+                                    {
+                                        "value": "text",
+                                        "text": "SMS"
                                     }
                                 ]
                             }) }}`

--- a/test/string-helper.test.js
+++ b/test/string-helper.test.js
@@ -1,0 +1,42 @@
+const createStringHelper = require('../lib/helpers/string');
+
+describe('String Helper', () => {
+    let stringHelper;
+
+    beforeEach(() => {
+        stringHelper = createStringHelper();
+    });
+
+    describe('containsHtml', () => {
+        it('should return false for an English sentence', () => {
+            const result = stringHelper.containsHtml(
+                'the quick brown fox jumped over the lazy dog.'
+            );
+            expect(result).toEqual(false);
+        });
+
+        it('should return false for an English sentence with special symbols', () => {
+            const result = stringHelper.containsHtml('the "quick" brown fox = foobar > 13');
+            expect(result).toEqual(false);
+        });
+
+        it('should return false for escaped HTML symbols', () => {
+            const result = stringHelper.containsHtml('lorem ipsum &lt;span&gt;');
+            expect(result).toEqual(false);
+        });
+
+        it('should return true for some HTML within a string', () => {
+            const result = stringHelper.containsHtml(
+                'This is a string with a <strong>valid</strong> HTML <a href="#foobar">hyperlink</a> inside it.'
+            );
+            expect(result).toEqual(true);
+        });
+
+        it('should return true for a string fully constructed of HTML', () => {
+            const result = stringHelper.containsHtml(
+                '<p>lorem ipsum <a href="#foobar"> foo bar</a>. <strong>something</strong> something.</p>'
+            );
+            expect(result).toEqual(true);
+        });
+    });
+});


### PR DESCRIPTION
Add extra transformer condition in the checkbox transformer. If there is only 1 item in the array of `anyOf` items, assumes it is now a page that will have a large fragment of HTML above the input element.