### PR TITLE
Correctly sort non-hidden questions

### DIFF
--- a/lib/transformers/summaryV2.js
+++ b/lib/transformers/summaryV2.js
@@ -12,11 +12,16 @@ function removeSectionIdPrefix(sectionId) {
 }
 
 function getDependentQuestionIds(value, fullUiSchema) {
-    const questionSchema = fullUiSchema[value.sectionId]?.options?.properties?.[value.id];
+    const sectionSchema = fullUiSchema[value.sectionId];
+    const questionSchema = sectionSchema?.options?.properties?.[value.id];
     const conditionalComponentMap = questionSchema?.options?.conditionalComponentMap;
+    const summaryOrder = sectionSchema?.options?.summaryOrder;
 
     if (conditionalComponentMap) {
         return conditionalComponentMap.flatMap(component => component.componentIds);
+    }
+    if (summaryOrder) {
+        return summaryOrder.slice(summaryOrder.indexOf(value.id) + 1);
     }
     return [];
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "q-transformer",
-    "version": "5.0.2",
+    "version": "5.0.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "q-transformer",
-            "version": "5.0.2",
+            "version": "5.0.3",
             "license": "MIT",
             "dependencies": {
                 "lodash.merge": "^4.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "q-transformer",
-    "version": "5.0.2",
+    "version": "5.0.3",
     "engines": {
         "npm": ">=8.5.2",
         "node": ">=16.0.0"

--- a/test/q-transformer.test.js
+++ b/test/q-transformer.test.js
@@ -1570,6 +1570,23 @@ describe('qTransformer', () => {
                                                                 valueLabel: '1',
                                                                 sectionId: 'p-baz',
                                                                 theme: 'foo'
+                                                            },
+                                                            {
+                                                                id: 'q-fourth',
+                                                                type: 'simple',
+                                                                label: 'Fourth',
+                                                                value: '4',
+                                                                sectionId: 'p-bar',
+                                                                theme: 'foo'
+                                                            },
+                                                            {
+                                                                id: 'q-third',
+                                                                type: 'simple',
+                                                                label: 'Third',
+                                                                value: '3',
+                                                                valueLabel: '3',
+                                                                sectionId: 'p-bar',
+                                                                theme: 'foo'
                                                             }
                                                         ]
                                                     }
@@ -1601,6 +1618,12 @@ describe('qTransformer', () => {
                                                         }
                                                     }
                                                 }
+                                            }
+                                        },
+                                        'p-bar': {
+                                            options: {
+                                                outputOrder: ['q-third', 'q-fourth'],
+                                                summaryOrder: ['q-third', 'q-fourth']
                                             }
                                         }
                                     }
@@ -1640,6 +1663,40 @@ describe('qTransformer', () => {
                                     '}\n' +
                                     ']\n' +
                                     '}\n';
+                                const qThird =
+                                    '"key": {\n' +
+                                    '"text": "Third",\n' +
+                                    '"classes": "govuk-!-width-one-half"\n' +
+                                    '},\n' +
+                                    '"value": {\n' +
+                                    '"html": "3"\n' +
+                                    '},\n' +
+                                    '"actions": {\n' +
+                                    '"items": [\n' +
+                                    '{\n' +
+                                    '"href": "/apply/bar?next=info-check-your-answers",\n' +
+                                    '"text": "Change",\n' +
+                                    '"visuallyHiddenText": "Third"\n' +
+                                    '}\n' +
+                                    ']\n' +
+                                    '}\n';
+                                const qFourth =
+                                    '"key": {\n' +
+                                    '"text": "Fourth",\n' +
+                                    '"classes": "govuk-!-width-one-half"\n' +
+                                    '},\n' +
+                                    '"value": {\n' +
+                                    '"html": "4"\n' +
+                                    '},\n' +
+                                    '"actions": {\n' +
+                                    '"items": [\n' +
+                                    '{\n' +
+                                    '"href": "/apply/bar?next=info-check-your-answers",\n' +
+                                    '"text": "Change",\n' +
+                                    '"visuallyHiddenText": "Fourth"\n' +
+                                    '}\n' +
+                                    ']\n' +
+                                    '}\n';
                                 const expected = {
                                     componentName: 'summary',
                                     content:
@@ -1654,6 +1711,12 @@ describe('qTransformer', () => {
                                         '},\n' +
                                         '{\n' +
                                         qSecond +
+                                        '},\n' +
+                                        '{\n' +
+                                        qThird +
+                                        '},\n' +
+                                        '{\n' +
+                                        qFourth +
                                         '}\n' +
                                         ']\n' +
                                         '}) }}',


### PR DESCRIPTION
Add functionality to sort the CYA page questions based on a new attribute in the UIschema to handle nested questions that are not conditionally revealed