### PR TITLE
Merge options from templates and UIschema

### DIFF
--- a/lib/q-transformer.js
+++ b/lib/q-transformer.js
@@ -52,6 +52,9 @@ function createQTransformer(
                 transformerOptions.options = instruction.options;
             }
         }
+        transformerOptions.options = transformerOptions.schema.options
+            ? transformerOptions.schema.options
+            : transformerOptions.options;
 
         const transformer = transformers[transformerName];
 

--- a/lib/transformers/summaryV2.js
+++ b/lib/transformers/summaryV2.js
@@ -11,7 +11,12 @@ function removeSectionIdPrefix(sectionId) {
     return sectionId.replace(/^p-/, '');
 }
 
-function getDependentQuestionIds(value, fullUiSchema) {
+function getDependentQuestionIds(value, schema, fullUiSchema) {
+    if (schema.options?.ordering) {
+        const questionOrdering = schema.options.ordering[value.id];
+        return questionOrdering || [];
+    }
+    // TODO: Remove the below when we remove reliance on UI schema
     const sectionSchema = fullUiSchema[value.sectionId];
     const questionSchema = sectionSchema?.options?.properties?.[value.id];
     const conditionalComponentMap = questionSchema?.options?.conditionalComponentMap;
@@ -26,12 +31,12 @@ function getDependentQuestionIds(value, fullUiSchema) {
     return [];
 }
 
-function dependentsInIncorrectOrder(value, values, valueIndex, fullUiSchema) {
+function dependentsInIncorrectOrder(value, values, valueIndex, schema, fullUiSchema) {
     if (valueIndex === 0) {
         return false;
     }
     const previousQuestionId = values[valueIndex - 1].id;
-    const dependentIds = getDependentQuestionIds(value, fullUiSchema);
+    const dependentIds = getDependentQuestionIds(value, schema, fullUiSchema);
     return dependentIds.includes(previousQuestionId);
 }
 
@@ -91,7 +96,9 @@ module.exports = ({schemaKey, schema, options, fullUiSchema} = {}) => {
                     if (schema.downloadSummary) {
                         delete summaryRow.actions;
                     }
-                    if (dependentsInIncorrectOrder(value, values, valueIndex, fullUiSchema)) {
+                    if (
+                        dependentsInIncorrectOrder(value, values, valueIndex, schema, fullUiSchema)
+                    ) {
                         insertSummaryRowBeforeDependent(summaryRows, summaryRow);
                     } else {
                         summaryRows.push(summaryRow);

--- a/lib/transformers/summaryV2.js
+++ b/lib/transformers/summaryV2.js
@@ -11,11 +11,7 @@ function removeSectionIdPrefix(sectionId) {
     return sectionId.replace(/^p-/, '');
 }
 
-function getDependentQuestionIds(value, schema, fullUiSchema) {
-    if (schema.options?.ordering) {
-        const questionOrdering = schema.options.ordering[value.id];
-        return questionOrdering || [];
-    }
+function getDependentQuestionIds(value, fullUiSchema) {
     // TODO: Remove the below when we remove reliance on UI schema
     const sectionSchema = fullUiSchema[value.sectionId];
     const questionSchema = sectionSchema?.options?.properties?.[value.id];
@@ -31,12 +27,12 @@ function getDependentQuestionIds(value, schema, fullUiSchema) {
     return [];
 }
 
-function dependentsInIncorrectOrder(value, values, valueIndex, schema, fullUiSchema) {
+function dependentsInIncorrectOrder(value, values, valueIndex, fullUiSchema) {
     if (valueIndex === 0) {
         return false;
     }
     const previousQuestionId = values[valueIndex - 1].id;
-    const dependentIds = getDependentQuestionIds(value, schema, fullUiSchema);
+    const dependentIds = getDependentQuestionIds(value, fullUiSchema);
     return dependentIds.includes(previousQuestionId);
 }
 
@@ -96,9 +92,7 @@ module.exports = ({schemaKey, schema, options, fullUiSchema} = {}) => {
                     if (schema.downloadSummary) {
                         delete summaryRow.actions;
                     }
-                    if (
-                        dependentsInIncorrectOrder(value, values, valueIndex, schema, fullUiSchema)
-                    ) {
+                    if (dependentsInIncorrectOrder(value, values, valueIndex, fullUiSchema)) {
                         insertSummaryRowBeforeDependent(summaryRows, summaryRow);
                     } else {
                         summaryRows.push(summaryRow);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "q-transformer",
-    "version": "5.0.3",
+    "version": "5.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "q-transformer",
-            "version": "5.0.3",
+            "version": "5.1.0",
             "license": "MIT",
             "dependencies": {
                 "lodash.merge": "^4.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "q-transformer",
-    "version": "5.0.3",
+    "version": "5.1.0",
     "engines": {
         "npm": ">=8.5.2",
         "node": ">=16.0.0"


### PR DESCRIPTION
As discussed the options property can now come from the templates themselves rather than UI schema. I've tested it locally and it has no effect on old versions of the template that rely entirely on the UI schema and works as expected when the options property is added to individual pages.
~The only place I've spotted it doesn't work completely smoothly is the ordering of conditionally revealed questions on the check your answers page. This is because the summary transformer relies on information from many pages but the only template passed is that of the summary page itself. However, this can easily be worked around by adding a summaryOrder property (as for the [explain reason for delay question](https://github.com/CriminalInjuriesCompensationAuthority/cica-web/blob/master/questionnaire/questionnaireUISchema.js#L286)) to the UI schema for any pages that require this. Preliminary tests show this has no effect on displaying the page for different template versions.~
~The CYA page transformation has to be handled differently as it needs information on other pages to sort the questions. This has been handled by adding a new property to the CYA page template, but leaving in support for using the UI schema for any older applications.~ The CYA page summary structure will be sorted before being returned to prevent differences between the ordering on the PDF and CYA page ([PR here](https://github.com/CriminalInjuriesCompensationAuthority/data-capture-service/pull/449))
This PR only adds the ability to put options onto individual templates, actually updating the templates can be done when the corresponding tickets are tackled. However, I did do a rough test where I added a conditional reveal to the 'have you been known by any names' question and the template worked fine for both the test and original versions.